### PR TITLE
Use authzforce 4.4.0 official image.

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -17,10 +17,12 @@ orion:
     command: -dbhost mongodb
 
 authzforce:
-    image: bitergia/authzforce:4.2.0
+    image: fiware/authzforce:4.4.0
     hostname: authzforce
     expose:
         - "8080"
+    # remove predefined domains before starting tomcat
+    command: bash -c "rm -rfv /opt/authzforce-ce-server/data/domains/* ; exec catalina.sh run"
 
 idm:
     image: bitergia/idm-keyrock:5.1.0
@@ -33,6 +35,7 @@ idm:
         - "5000"
     environment:
         - APP_NAME=TourGuide
+        - AUTHZFORCE_VERSION=4.4.0
 
 pepwilma:
     image: bitergia/pep-wilma:4.3.0
@@ -48,6 +51,7 @@ pepwilma:
     environment:
         - APP_HOSTNAME=orion
         - APP_PORT=1026
+        - AUTHZFORCE_VERSION=4.4.0
 
 idasiotacpp:
     image: bitergia/idas-iota-cpp:1.2.0


### PR DESCRIPTION
Though authzforce image is not yet automated, it is at [Docker Hub](https://hub.docker.com/r/fiware/authzforce/) and we can start using it.  This is the first step in moving from our custom images to the official ones (see #43).
