### PR TITLE
Temporary fix until authzforce docker image uses versioned tags.

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -17,7 +17,7 @@ orion:
     command: -dbhost mongodb
 
 authzforce:
-    image: fiware/authzforce:4.4.0
+    image: fiware/authzforce-ce-server:latest
     hostname: authzforce
     expose:
         - "8080"


### PR DESCRIPTION
This makes tourguide functional again until #50 is fixed.
