### PR TITLE
Use official pep-wilma docker image.

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -36,7 +36,7 @@ idm:
         - AUTHZFORCE_VERSION=4.4.1b
 
 pepwilma:
-    image: bitergia/pep-wilma:4.3.0
+    image: fiware/pep-proxy:latest
     hostname: pepwilma
     links:
         - orion
@@ -44,12 +44,15 @@ pepwilma:
         - authzforce
     volumes_from:
         - idm
+        - tourguide-config
     expose:
         - "1026"
     environment:
         - APP_HOSTNAME=orion
         - APP_PORT=1026
         - AUTHZFORCE_VERSION=4.4.1b
+        - PEP_RELEASE=5.1
+    entrypoint: /tourguide/pep-wilma/docker-entrypoint.sh
 
 idasiotacpp:
     image: bitergia/idas-iota-cpp:1.2.0

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -50,7 +50,6 @@ pepwilma:
     environment:
         - APP_HOSTNAME=orion
         - APP_PORT=1026
-        - AUTHZFORCE_VERSION=4.4.1b
         - PEP_RELEASE=5.1
     entrypoint: /tourguide/pep-wilma/docker-entrypoint.sh
 

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -131,3 +131,11 @@ tourguide:
         - idm
     # volumes:
     #     - ~/devel/fiware/tutorials.TourGuide-App:/home/tourguide/tutorials.TourGuide-App
+
+tourguide-config:
+    build: ../images/tutorials.tourguide-app.config
+    hostname: tourguide-config
+    volumes:
+        - /tourguide
+    entrypoint: echo 'tourguide configuration'
+    restart: "no"

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -6,7 +6,7 @@ mongodb:
     command: --smallfiles
 
 orion:
-    image: fiware/orion:0.26.1
+    image: fiware/orion:0.28
     hostname: orion
     links:
         - mongodb

--- a/docker/images/tutorials.tourguide-app.config/Dockerfile
+++ b/docker/images/tutorials.tourguide-app.config/Dockerfile
@@ -5,4 +5,5 @@ FROM busybox
 MAINTAINER Bitergia <fiware-testing@bitergia.com>
 
 ADD https://raw.githubusercontent.com/Bitergia/docker/master/utils/entrypoint-common.sh /tourguide/common/entrypoint-common.sh
+COPY pep-wilma /tourguide/pep-wilma
 

--- a/docker/images/tutorials.tourguide-app.config/Dockerfile
+++ b/docker/images/tutorials.tourguide-app.config/Dockerfile
@@ -1,0 +1,8 @@
+# Copyright(c) 2016 Bitergia
+# MIT Licensed
+
+FROM busybox
+MAINTAINER Bitergia <fiware-testing@bitergia.com>
+
+ADD https://raw.githubusercontent.com/Bitergia/docker/master/utils/entrypoint-common.sh /tourguide/common/entrypoint-common.sh
+

--- a/docker/images/tutorials.tourguide-app.config/pep-wilma/auth-token.sh
+++ b/docker/images/tutorials.tourguide-app.config/pep-wilma/auth-token.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+if [ $# -lt 2 ] ; then
+    echo "auth-token: missing parameters."
+    echo "Usage: auth-token <user-email> <password>"
+    exit 1
+fi
+
+# Retrieve X-Auth-Token to make request against the protected resource
+
+function get_token () {
+
+    if [ $# -lt 2 ] ; then
+    echo "get_token: missing parameters."
+    echo "Usage: get_token <user-email> <password>"
+    exit 1
+    fi
+
+    local _user=$1
+    local _pass=$2
+
+    # Retrieve Client ID and client Secret Automatically
+
+    CLIENT_ID="$(cat /config/idm2chanchan.json | awk '/id/{print $NF}' | cut -d '"' -f2)"
+    CLIENT_SECRET="$(cat /config/idm2chanchan.json | awk '/secret/{print $NF}' | cut -d '"' -f2)"
+
+    # Generate the Authentication Header for the request
+
+    AUTH_HEADER="$(echo -n ${CLIENT_ID}:${CLIENT_SECRET} | base64 -w 0)"
+
+    # Define headers
+
+    CONTENT_TYPE="\"Content-Type: application/x-www-form-urlencoded\""
+    AUTH_BASIC="\"Authorization: Basic ${AUTH_HEADER}\""
+
+    # Define data to send
+
+    DATA="'grant_type=password&username=${_user}&password=${_pass}&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}'"
+
+    # Create the request
+
+    REQUEST="curl -s --insecure -i --header ${AUTH_BASIC} --header ${CONTENT_TYPE} -X POST https://idm/oauth2/token -d ${DATA}"
+    XAUTH_TOKEN="$(eval ${REQUEST} | grep -Po '(?<="access_token": ")[^"]*')"
+    echo "X-Auth-Token for '${_user}': ${XAUTH_TOKEN}"
+    
+}
+
+get_token $1 $2

--- a/docker/images/tutorials.tourguide-app.config/pep-wilma/config.js
+++ b/docker/images/tutorials.tourguide-app.config/pep-wilma/config.js
@@ -1,0 +1,45 @@
+var config = {};
+
+config.pep_port = PEP_PORT;
+
+// Set this var to undefined if you don't want the server to listen on HTTPS
+// config.https = {
+//    enabled: false,
+//    cert_file: 'cert/cert.crt',
+//    key_file: 'cert/key.key',
+//    port: 443
+//};
+
+// Our IdM IP
+config.account_host = 'IDM_KEYSTONE_HOSTNAME';
+
+// Our Keystone Settings. In this case Keystone and Horizon are at the same host
+config.keystone_host = 'IDM_KEYSTONE_HOSTNAME';
+config.keystone_port = IDM_KEYSTONE_PORT;
+
+// The host of the app to protect
+config.app_host = 'APP_HOSTNAME';
+config.app_port = APP_PORT;
+
+// The username and password we've used for registering the app (just for testing)
+config.username = 'PEP_USERNAME';
+config.password = 'PEP_PASSWORD';
+
+// in seconds
+config.chache_time = 300;
+
+// if enabled PEP checks permissions with AuthZForce GE.
+// only compatible with oauth2 tokens engine
+config.azf = {
+    enabled: true,
+    host: 'AUTHZFORCE_HOSTNAME',
+    port: AUTHZFORCE_PORT,
+    path: '/authzforce/domains/DOMAIN/pdp'
+};
+
+// options: oauth2/keystone
+config.tokens_engine = 'oauth2';
+
+config.magic_key = 'MAGIC_KEY';
+
+module.exports = config;

--- a/docker/images/tutorials.tourguide-app.config/pep-wilma/docker-entrypoint.sh
+++ b/docker/images/tutorials.tourguide-app.config/pep-wilma/docker-entrypoint.sh
@@ -49,7 +49,7 @@ if [ $# -eq 0 -o "${1:0:1}" = '-' ] ; then
 
     check_var AUTHZFORCE_HOSTNAME authzforce
     check_var AUTHZFORCE_PORT 8080
-    check_var AUTHZFORCE_VERSION 4.2.0
+    check_var AUTHZFORCE_VERSION 4.4.1b
     case "${AUTHZFORCE_VERSION}" in
         "4.2.0")
             check_var AUTHZFORCE_BASE_PATH authzforce

--- a/docker/images/tutorials.tourguide-app.config/pep-wilma/docker-entrypoint.sh
+++ b/docker/images/tutorials.tourguide-app.config/pep-wilma/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y --no-install-recommends curl
+source /tourguide/common/entrypoint-common.sh
+
+declare DOMAIN=''
+
+function get_domain () {
+
+    if [ $# -lt 2 ] ; then
+        echo "check_host_port: missing parameters."
+        echo "Usage: check_host_port <host> <port> [max-tries]"
+        exit 1
+    fi
+
+    local _host=$1
+    local _port=$2
+
+    # Request to Authzforce to retrieve Domain
+
+    DOMAIN=$( curl -s --request GET http://${_host}:${_port}/${AUTHZFORCE_BASE_PATH}/domains | awk '/href/{print $NF}' | cut -d '"' -f2 )
+    echo "Domain retrieved: $DOMAIN"
+
+}
+
+# Configure Domain permissions to user 'pepproxy' at IdM.
+# TODO: make it more configurable
+
+function domain_permissions() {
+
+    local _host=$1
+    local _port=$2
+
+    FRESHTOKEN=$( curl -s -i   -H "Content-Type: application/json"   -d '{ "auth": {"identity": {"methods": ["password"], "password": { "user": { "name": "idm", "domain": { "id": "default" }, "password": "idm"} } } } }' http://${_host}:${_port}/v3/auth/tokens | grep ^X-Subject-Token: | awk '{print $2}' )
+    MEMBERID=$( curl -s -H "X-Auth-Token:${FRESHTOKEN}" -H "Content-type: application/json" http://${_host}:${_port}/v3/roles | python -m json.tool | grep -iw id | awk -F'"' '{print $4}' | head -n 1 )
+    REQUEST=$( curl -s -X PUT -H "X-Auth-Token:${FRESHTOKEN}" -H "Content-type: application/json" http://${_host}:${_port}/v3/domains/default/users/pepproxy/roles/${MEMBERID} )
+    echo "User pepproxy has been granted with:"
+    echo "Role: ${MEMBERID}"
+    echo "Token:  ${FRESHTOKEN}"
+
+}
+
+if [ $# -eq 0 -o "${1:0:1}" = '-' ] ; then
+
+    check_var WILMA_HOME /opt/fiware-pep-proxy
+    check_var WILMA_USER pepproxy
+    check_var PEP_RELEASE 5.1
+
+    check_var AUTHZFORCE_HOSTNAME authzforce
+    check_var AUTHZFORCE_PORT 8080
+    check_var AUTHZFORCE_VERSION 4.2.0
+    case "${AUTHZFORCE_VERSION}" in
+        "4.2.0")
+            check_var AUTHZFORCE_BASE_PATH authzforce
+            ;;
+        *)
+            check_var AUTHZFORCE_BASE_PATH authzforce-ce
+            ;;
+    esac
+    check_var IDM_KEYSTONE_HOSTNAME idm
+    check_var IDM_KEYSTONE_PORT 5000
+    check_var APP_HOSTNAME orion
+    check_var APP_PORT 1026
+    check_var PEP_USERNAME pepproxy@test.com
+    check_var PEP_PASSWORD test
+    check_var PEP_PORT 1026
+    check_var IDM_USERNAME user0@test.com
+    check_var IDM_USERPASS test
+    check_var MAGIC_KEY daf26216c5434a0a80f392ed9165b3b4
+
+    # fix variables when using docker-compose
+    if [[ ${AUTHZFORCE_PORT} =~ ^tcp://[^:]+:(.*)$ ]] ; then
+        export AUTHZFORCE_PORT=${BASH_REMATCH[1]}
+    fi
+    if [[ ${IDM_KEYSTONE_PORT} =~ ^tcp://[^:]+:(.*)$ ]] ; then
+        export IDM_KEYSTONE_PORT=${BASH_REMATCH[1]}
+    fi
+    if [[ ${APP_PORT} =~ ^tcp://[^:]+:(.*)$ ]] ; then
+        export ORION_PORT=${BASH_REMATCH[1]}
+    fi
+
+    # Call checks
+
+    check_file /config/domain-ready || exit 1
+    get_domain ${AUTHZFORCE_HOSTNAME} ${AUTHZFORCE_PORT}
+    check_file /config/provision-ready || exit 1
+    check_host_port ${IDM_KEYSTONE_HOSTNAME} ${IDM_KEYSTONE_PORT}
+    domain_permissions ${IDM_KEYSTONE_HOSTNAME} ${IDM_KEYSTONE_PORT}
+
+    cp /tourguide/pep-wilma/auth-token.sh /usr/local/bin/auth-token.sh
+    chmod 755 /usr/local/bin/auth-token.sh
+
+    # Configure PEP Proxy config.js
+
+    cd ${WILMA_HOME}
+    git checkout ${PEP_RELEASE}
+    npm install
+    cp /tourguide/pep-wilma/config.js ${WILMA_HOME}/config.js
+    sed -i ${WILMA_HOME}/config.js \
+        -e "s|PEP_PORT|${PEP_PORT}|g" \
+        -e "s|IDM_KEYSTONE_HOSTNAME|${IDM_KEYSTONE_HOSTNAME}|g" \
+        -e "s|IDM_KEYSTONE_PORT|${IDM_KEYSTONE_PORT}|g" \
+        -e "s|APP_HOSTNAME|${APP_HOSTNAME}|g" \
+        -e "s|APP_PORT|${APP_PORT}|g" \
+        -e "s|PEP_USERNAME|${PEP_USERNAME}|g" \
+        -e "s|PEP_PASSWORD|${PEP_PASSWORD}|g" \
+        -e "s|AUTHZFORCE_HOSTNAME|${AUTHZFORCE_HOSTNAME}|g" \
+        -e "s|AUTHZFORCE_PORT|${AUTHZFORCE_PORT}|g" \
+        -e "s|DOMAIN|${DOMAIN}|g" \
+        -e "s|MAGIC_KEY|${MAGIC_KEY}|g"
+
+    # Create PEP user
+    adduser --disabled-password --gecos "${WILMA_USER}" ${WILMA_USER}
+
+    # Install forever
+    npm install forever --global
+
+    # Start PEP Proxy
+    cd ${WILMA_HOME}
+    su - ${WILMA_USER} -c "cd ${WILMA_HOME} ; PORT=${PEP_PORT} NODE_ENV=development forever start server.js"
+    exec su - ${WILMA_USER} -c "forever --fifo logs 0"
+else
+    exec "$@"
+fi

--- a/docker/images/tutorials.tourguide-app/Dockerfile
+++ b/docker/images/tutorials.tourguide-app/Dockerfile
@@ -10,7 +10,7 @@ ENV INITRD no
 ENV TOURGUIDE_USER tourguide
 ENV TOURGUIDE_USER_DIR /home/${TOURGUIDE_USER}
 ENV GIT_URL_TOURGUIDE https://github.com/Fiware/tutorials.TourGuide-App.git
-ENV GIT_REV_TOURGUIDE master
+ENV GIT_REV_TOURGUIDE develop
 ENV SUBSCRIPTIONS_PATH /opt/subscribe
 ENV CEP_DEFINITIONS_PATH /opt/cep
 ENV CC_APP_SERVER_PATH ${TOURGUIDE_USER_DIR}/tutorials.TourGuide-App/server
@@ -70,7 +70,7 @@ USER ${TOURGUIDE_USER}
 WORKDIR ${TOURGUIDE_USER_DIR}
 
 # get the repository from git and install node dependencies
-RUN git clone ${GIT_URL_TOURGUIDE} && \
+RUN git clone -b ${GIT_REV_TOURGUIDE} ${GIT_URL_TOURGUIDE} && \
     cd ${CC_APP_SERVER_PATH} && \
     npm install --loglevel warn && \
     rm -fr ${TOURGUIDE_USER_DIR}/.npm


### PR DESCRIPTION
This allows us to use the official pep-wilma docker image while keeping the modifications done on [Bitergia's pep-wilma image](https://hub.docker.com/r/bitergia/pep-wilma/).  This is another step in fixing #43.
