### PR TITLE
Use authzforce 4.4.1b official docker image.

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -17,12 +17,10 @@ orion:
     command: -dbhost mongodb
 
 authzforce:
-    image: fiware/authzforce-ce-server:latest
+    image: fiware/authzforce-ce-server:release-4.4.1b
     hostname: authzforce
     expose:
         - "8080"
-    # remove predefined domains before starting tomcat
-    command: bash -c "rm -rfv /opt/authzforce-ce-server/data/domains/* ; exec catalina.sh run"
 
 idm:
     image: bitergia/idm-keyrock:5.1.0
@@ -35,7 +33,7 @@ idm:
         - "5000"
     environment:
         - APP_NAME=TourGuide
-        - AUTHZFORCE_VERSION=4.4.0
+        - AUTHZFORCE_VERSION=4.4.1b
 
 pepwilma:
     image: bitergia/pep-wilma:4.3.0
@@ -51,7 +49,7 @@ pepwilma:
     environment:
         - APP_HOSTNAME=orion
         - APP_PORT=1026
-        - AUTHZFORCE_VERSION=4.4.0
+        - AUTHZFORCE_VERSION=4.4.1b
 
 idasiotacpp:
     image: bitergia/idas-iota-cpp:1.2.0


### PR DESCRIPTION
Now that authzforce/fiware#3 has been fixed, we can use versioned tags again.  This updates master to use the authzforce 4.4.1b official docker image.  This fixes half of #50, pending a new release with this fix.
