### PR TITLE
Fix orion data models

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -6,7 +6,7 @@ mongodb:
     command: --smallfiles
 
 orion:
-    image: fiware/orion:0.26.1
+    image: fiware/orion:0.28
     hostname: orion
     links:
         - mongodb

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,5 +1,5 @@
 mongodb:
-    image: fiware/tutorials.tourguide-app.restaurant-data:20160201
+    image: fiware/tutorials.tourguide-app.restaurant-data:20160329
     hostname: mongodb
     expose:
         - "27017"

--- a/server/auth/authrequest.js
+++ b/server/auth/authrequest.js
@@ -21,7 +21,7 @@ var port = 1026;
 
 module.exports = performRequest;
 
-function performRequest(endpoint, method, data, fiwareHeaders) {
+function performRequest(endpoint, method, data, fiwareHeaders, payload) {
 
   var deferred = Q.defer();
   var headers = {};
@@ -54,9 +54,12 @@ function performRequest(endpoint, method, data, fiwareHeaders) {
       resolveWithFullResponse: true,
       json: true // Automatically stringifies the body to JSON
     };
+    if (typeof payload !== 'undefined') {
+      endpoint += '?' + querystring.stringify(payload);
+      options.uri = host + ':' + port + endpoint;
+    }
     break;
   case 'PATCH':
-    endpoint += '?' + querystring.stringify(data);
     options = {
       method: 'PATCH',
       uri: host + ':' + port + endpoint,
@@ -65,6 +68,10 @@ function performRequest(endpoint, method, data, fiwareHeaders) {
       resolveWithFullResponse: true,
       json: true
     };
+    if (typeof payload !== 'undefined') {
+      endpoint += '?' + querystring.stringify(payload);
+      options.uri = host + ':' + port + endpoint;
+    }
     break;
   case 'DELETE':
     endpoint += '?' + querystring.stringify(data);

--- a/server/feeders/reservationsgenerator.js
+++ b/server/feeders/reservationsgenerator.js
@@ -43,7 +43,6 @@ var feedOrionReservations = function() {
   // Limit the number of calls to be done in parallel to orion
   var q = async.queue(function(task, callback) {
     var attributes = task.attributes;
-
     utils.sendRequest('POST', attributes, null, fiwareHeaders)
     .then(callback)
     .catch(function(err) {
@@ -56,28 +55,37 @@ var feedOrionReservations = function() {
   };
 
   Object.keys(restaurantsData).forEach(function(element, pos) {
-    // Call orion to append the entity
-    var restaurantName = restaurantsData[pos].id + '-' + shortid.generate();
+
+    var reservationId = restaurantsData[pos].id + '-' + shortid.generate();
 
     var reservations = ['Cancelled', 'Confirmed', 'Hold', 'Pending'];
 
     var attr = {
       'type': 'FoodEstablishmentReservation',
-      'id': restaurantName,
-      'reservationStatus': utils.randomElement(reservations),
-      'underName': {},
-      'reservationFor': {},
-      'startTime': utils.getRandomDate().getTime(),
-      'partySize': utils.randomIntInc(1, 20)
+      'id': utils.asciiEncode(reservationId),
+      'reservationStatus': {
+        'value': utils.randomElement(reservations)
+      },
+      'underName': {
+        'type': 'Person',
+        'value': 'user' + utils.randomIntInc(1, 10)
+      },
+      'reservationFor': {
+        'type': 'FoodEstablishment',
+        'value': utils.fixedEncodeURIComponent(restaurantsData[pos].name)
+      },
+      'address': {
+        'type': 'PostalAddress',
+        'value': restaurantsData[pos].address
+      },
+      'startTime': {
+        'type': 'date',
+        'value': utils.getRandomDate().toISOString()
+      },
+      'partySize': {
+        'value': utils.randomIntInc(1, 20)
+      }
     };
-
-    // Time to add first attribute to orion as first approach
-    attr.underName.type = 'Person';
-    attr.underName.name = 'user' + utils.randomIntInc(1, 10);
-
-    attr.reservationFor.type = 'FoodEstablishment';
-    attr.reservationFor.name = restaurantsData[pos].id;
-    attr.reservationFor.address = restaurantsData[pos].address;
 
     q.push({
       'attributes': attr

--- a/server/feeders/restaurantfeeder.js
+++ b/server/feeders/restaurantfeeder.js
@@ -132,28 +132,39 @@ var feedOrionRestaurants = function() {
 
     var attr = {
       'type': 'Restaurant',
-      'id': utils.fixedEncodeURIComponent(rname),
+      'id': utils.asciiEncode(utils.stripForbiddenChars(rname)),
       'address': {
-        'type': 'postalAddress'
+        'type': 'PostalAddress',
+        'value': {}
       },
-      'department': utils.randomElement(organization),
+      'name': {
+        'value': utils.fixedEncodeURIComponent(rname)
+      },
+      'department': {
+        'value': utils.randomElement(organization)
+      },
       'capacity': {
         'type': 'PropertyValue',
-        'name': 'capacity',
         'value': utils.randomElement(capacity)
       },
-      'aggregateRating': {},
+      'aggregateRating': {
+        'type': 'AggregateRating',
+        'value': {}
+      },
       'occupancyLevels': {
+        'metadata': {
+          'timestamp': {
+            'type': 'date',
+            'value': new Date().toISOString()
+          }
+        },
         'type': 'PropertyValue',
-        // timestamp in ms
-        'timestamp': new Date().getTime(),
-        'name': 'occupancyLevels',
         'value': 0
       }
     };
 
-    attr.aggregateRating.ratingValue = utils.randomIntInc(1, 5);
-    attr.aggregateRating.reviewCount = utils.randomIntInc(1,
+    attr.aggregateRating.value.ratingValue = utils.randomIntInc(1, 5);
+    attr.aggregateRating.value.reviewCount = utils.randomIntInc(1,
       100);
 
     Object.keys(restaurantsData[pos]).forEach(function(element) {
@@ -163,12 +174,13 @@ var feedOrionRestaurants = function() {
       if (element in addressDictionary) {
 
         if (val !== 'undefined' && val !== '') {
-          element = utils.replaceOnceUsingDictionary(
+          element = utils.fixedEncodeURIComponent(
+            utils.replaceOnceUsingDictionary(
             addressDictionary, element,
             function(key, dictionary) {
               return dictionary[key];
-            });
-          attr.address[utils.fixedEncodeURIComponent(element)] =
+            }));
+          attr.address.value[element] =
           utils.fixedEncodeURIComponent(val);
         }
 
@@ -177,16 +189,19 @@ var feedOrionRestaurants = function() {
 
           if (val !== 'undefined' && val !== '') {
 
-            element = utils.replaceOnceUsingDictionary(
+            element = utils.fixedEncodeURIComponent(
+              utils.replaceOnceUsingDictionary(
               dictionary, element,
               function(key, dictionary) {
                 return dictionary[key];
-              });
+              }));
             if (element == 'priceRange') {
-              attr[utils.fixedEncodeURIComponent(element)] =
+              attr[element] = {};
+              attr[element].value =
               parseFloat(val);
             } else {
-              attr[utils.fixedEncodeURIComponent(element)] =
+              attr[element] = {};
+              attr[element].value =
               utils.fixedEncodeURIComponent(
               utils.convertHtmlToText(val));
             }

--- a/server/feeders/restaurantfeeder.js
+++ b/server/feeders/restaurantfeeder.js
@@ -38,12 +38,12 @@ var fiwareHeaders = {
 };
 
 var getAddress = function(restaurant) {
-  var address = restaurant.address.streetAddress + ' ';
-  if (restaurant.address.addressLocality) {
-    address += restaurant.address.addressLocality + ' ';
+  var address = restaurant.address.value.streetAddress + ' ';
+  if (restaurant.address.value.addressLocality) {
+    address += restaurant.address.value.addressLocality + ' ';
   }
-  if (restaurant.address.addressRegion) {
-    address += restaurant.address.addressRegion;
+  if (restaurant.address.value.addressRegion) {
+    address += restaurant.address.value.addressRegion;
   }
   return address;
 };
@@ -74,8 +74,8 @@ var feedOrionRestaurants = function() {
     .catch(function(err) {
       if (err.statusCode == '404') {
         var address = getAddress(attributes);
-        if (typeof attributes.department !== 'undefined') {
-          fwHeaders['fiware-servicepath'] = '/' + attributes.department;
+        if (typeof attributes.department.value !== 'undefined') {
+          fwHeaders['fiware-servicepath'] = '/' + attributes.department.value;
         }
         setTimeout(function() {
          geocoder.geocode({address: address, country: 'Spain'})

--- a/server/feeders/reviewsgenerator.js
+++ b/server/feeders/reviewsgenerator.js
@@ -109,16 +109,24 @@ var triggerRestaurantsRatings = function() {
   var servicePath;
 
   var q = async.queue(function(task, callback) {
-
+    var restaurantId = utils.asciiEncode(
+      utils.stripForbiddenChars(
+        unescape(task.restaurantName)));
     setTimeout(function() {
-      utils.getListByType('Restaurant', task.restaurantName, fiwareHeaders)
+      utils.getListByType(
+        'Restaurant',
+        restaurantId,
+        fiwareHeaders)
       .then(function(data) {
         var fwHeaders = JSON.parse(JSON.stringify(fiwareHeaders));
         if (typeof data.body.department !== 'undefined') {
           fwHeaders['fiware-servicepath'] = '/' + data.body.department;
         }
-        utils.sendRequest('PATCH', task.aggregateRatings,
-          task.restaurantName, fwHeaders)
+        utils.sendRequest(
+          'PATCH',
+          task.aggregateRatings,
+          restaurantId,
+          fwHeaders)
         .then(callback)
         .catch(function(err) {
           console.log(err.error);
@@ -128,7 +136,6 @@ var triggerRestaurantsRatings = function() {
         console.log(err.error);
       });
     }, delay);
-
   }, apiRestSimtasks);
 
   q.drain = function() {
@@ -139,7 +146,7 @@ var triggerRestaurantsRatings = function() {
   .then(function(data) {
     reviews = data.body;
     Object.keys(restaurantsData).forEach(function(element, pos) {
-      var restaurantName = restaurantsData[pos].id;
+      var restaurantName = restaurantsData[pos].name;
       restaurantReviews = utils.getRestaurantReviews(
         restaurantName,
         reviews);

--- a/server/feeders/reviewsgenerator.js
+++ b/server/feeders/reviewsgenerator.js
@@ -15,7 +15,7 @@
   - Create more real reviews using templates for comments and random ratings
 */
 
-// jshint node: true
+// jshint node: true, nonstandard: true
 
 'use strict';
 
@@ -47,7 +47,6 @@ var feedOrionReviews = function() {
   // Limit the number of calls to be done in parallel to orion
   var q = async.queue(function(task, callback) {
     var attributes = task.attributes;
-
     utils.sendRequest('POST', attributes, null, fiwareHeaders)
     .then(callback)
     .catch(function(err) {
@@ -61,33 +60,36 @@ var feedOrionReviews = function() {
   };
 
   Object.keys(restaurantsData).forEach(function(element, pos) {
-    // Call orion to append the entity
-    var rname = restaurantsData[pos].id;
-    rname += '-' + shortid.generate();
-    // Time to add first attribute to orion as first approach
+
+    var reviewId = restaurantsData[pos].id + '-' + shortid.generate();
 
     var attr = {
       'type': 'Review',
-      'id': rname,
-      'itemReviewed': {},
-      'reviewRating': {},
-      'author': {},
-      'reviewBody': 'Body review',
-      'dateCreated': new Date().getTime(),
-      'publisher': {}
+      'id': utils.asciiEncode(reviewId),
+      'itemReviewed': {
+        'type': 'Restaurant',
+        'value': utils.fixedEncodeURIComponent(restaurantsData[pos].name)
+      },
+      'reviewRating': {
+        'type': 'Rating',
+        'value': utils.randomIntInc(1, 5)
+      },
+      'author': {
+        'type': 'Person',
+        'value': 'user' + utils.randomIntInc(1, 10)
+      },
+      'reviewBody': {
+        'value': 'Body review'
+      },
+      'dateCreated': {
+        'type': 'date',
+        'value': new Date().toISOString()
+      },
+      'publisher': {
+        'type': 'Organization',
+        'value': 'Bitergia'
+      }
     };
-
-    attr.itemReviewed.type = 'Restaurant';
-    attr.itemReviewed.name = restaurantsData[pos].id;
-
-    attr.reviewRating.type = 'Rating';
-    attr.reviewRating.ratingValue = utils.randomIntInc(1, 5);
-
-    attr.author.type = 'Person';
-    attr.author.name = 'user' + utils.randomIntInc(1, 10);
-
-    attr.publisher.type = 'Organization';
-    attr.publisher.name = 'Bitergia';
 
     q.push({
       'attributes': attr

--- a/server/routes/orion.js
+++ b/server/routes/orion.js
@@ -87,6 +87,7 @@ exports.readRestaurant = function(req, res) {
   var restaurant;
   var fiwareHeaders;
   var actualDate = new Date().getTime();
+  var restaurantId = utils.nameToId(req.params.id);
   timeframeQuery = utils.getTimeframe(actualDate);
   utils.sendRequest('GET', {
         'type': 'FoodEstablishmentReservation',
@@ -99,11 +100,10 @@ exports.readRestaurant = function(req, res) {
       restaurantReservations = data.body;
       actualOccupancyLevels = utils.getOccupancyLevels(
         restaurantReservations,
-        req.params.id);
-      console.log(actualOccupancyLevels);
+        restaurantId);
       occupancyLevelsObject = utils.updateOccupancyLevels(
         actualOccupancyLevels, actualDate);
-      utils.getListByType('Restaurant', req.params.id, req.headers)
+      utils.getListByType('Restaurant', restaurantId, req.headers)
         .then(function(data) {
           restaurant = data.body;
           // add service path for the restaurant
@@ -114,10 +114,10 @@ exports.readRestaurant = function(req, res) {
           }
           utils.sendRequest('PATCH',
               occupancyLevelsObject,
-              req.params.id,
+              restaurantId,
               fiwareHeaders)
             .then(function(data) {
-              utils.getListByType('Restaurant', req.params.id, req.headers)
+              utils.getListByType('Restaurant', restaurantId, req.headers)
                 .then(function(data) {
                   res.statusCode = data.statusCode;
                   res.json(utils.dataToSchema(data.body));
@@ -150,6 +150,7 @@ exports.readRestaurantWithDate = function(req, res) {
   var occupancyLevelsObject;
   var restaurant;
   var fiwareHeaders;
+  var restaurantId = utils.nameToId(req.params.id);
   timeframeQuery = utils.getTimeframe(req.params.date);
   utils.sendRequest('GET', {
         'type': 'FoodEstablishmentReservation',
@@ -163,10 +164,9 @@ exports.readRestaurantWithDate = function(req, res) {
       actualOccupancyLevels = utils.getOccupancyLevels(
         restaurantReservations,
         req.params.id);
-      console.log(actualOccupancyLevels);
       occupancyLevelsObject = utils.updateOccupancyLevels(
         actualOccupancyLevels, req.params.date);
-      utils.getListByType('Restaurant', req.params.id, req.headers)
+      utils.getListByType('Restaurant', restaurantId, req.headers)
         .then(function(data) {
           restaurant = data.body;
           // add service path for the restaurant
@@ -180,7 +180,7 @@ exports.readRestaurantWithDate = function(req, res) {
               req.params.id,
               fiwareHeaders)
             .then(function(data) {
-              utils.getListByType('Restaurant', req.params.id, req.headers)
+              utils.getListByType('Restaurant', restaurantId, req.headers)
                 .then(function(data) {
                   res.statusCode = data.statusCode;
                   res.json(utils.dataToSchema(data.body));
@@ -224,7 +224,8 @@ exports.updateRestaurant = function(req, res) {
 };
 
 exports.deleteRestaurant = function(req, res) {
-  utils.sendRequest('DELETE', null, req.params.id, req.headers)
+  var restaurantId = utils.nameToId(req.params.id);
+  utils.sendRequest('DELETE', null, restaurantId, req.headers)
     .then(function(data) {
       res.statusCode = data.statusCode;
       res.end();
@@ -270,6 +271,7 @@ exports.getOrganizationRestaurants = function(req, res) {
 exports.createReview = function(req, res) {
   var elementToOrion = req.body;
   var restaurantName = elementToOrion.itemReviewed.name;
+  var restaurantId = utils.nameToId(restaurantName);
   var restaurantReviews;
   var aggregateRatings;
   var valid = tv4.validate(elementToOrion, 'review');
@@ -279,7 +281,7 @@ exports.createReview = function(req, res) {
     if (typeof fwHeaders['fiware-servicepath'] !== 'undefined') {
       delete fwHeaders['fiware-servicepath'];
     }
-    utils.getListByType('Restaurant', restaurantName, fwHeaders)
+    utils.getListByType('Restaurant', restaurantId, fwHeaders)
     .then(function(data) {
       auth.getUserDataPromise(req)
       .then(function(data) {
@@ -294,7 +296,7 @@ exports.createReview = function(req, res) {
             aggregateRatings = utils.getAggregateRating(
               restaurantReviews);
             utils.sendRequest('PATCH', aggregateRatings,
-              restaurantName, req.headers)
+              restaurantId, req.headers)
               .then(function(data) {
                 res.end();
               })
@@ -342,7 +344,8 @@ exports.createReview = function(req, res) {
 };
 
 exports.readReview = function(req, res) {
-  utils.getListByType('Review', req.params.id, req.headers)
+  var reviewId = utils.nameToId(req.params.id);
+  utils.getListByType('Review', reviewId, req.headers)
     .then(function(data) {
       res.statusCode = data.statusCode;
       res.json(utils.dataToSchema(data.body));
@@ -357,13 +360,16 @@ exports.updateReview = function(req, res) {
   var restaurantReviews;
   var aggregateRatings;
   var restaurantName;
+  var restaurantId;
   var userId;
   var servicePath;
   var fixedReviewObject;
-  utils.getListByType('Review', req.params.id, req.headers)
+  var reviewId = utils.nameToId(req.params.id);
+  utils.getListByType('Review', reviewId, req.headers)
     .then(function(data) {
-      restaurantName = data.body.itemReviewed.name;
-      userId = data.body.author.name;
+      restaurantName = data.body.itemReviewed;
+      restaurantId = utils.nameToId(restaurantName);
+      userId = data.body.author;
       auth.getUserDataPromise(req)
         .then(function(data) {
           if (userId !== data.id) {
@@ -396,14 +402,14 @@ exports.updateReview = function(req, res) {
                       data.body);
                     aggregateRatings = utils.getAggregateRating(
                       restaurantReviews);
-                    utils.getListByType('Restaurant', restaurantName,
+                    utils.getListByType('Restaurant', restaurantId,
                         req.headers)
                       .then(function(data) {
                         servicePath = data.body.department;
                         req.headers['fiware-servicepath'] = '/' +
                           servicePath;
                         utils.sendRequest('PATCH', aggregateRatings,
-                            restaurantName, req.headers)
+                            restaurantId, req.headers)
                           .then(function(data) {
                             res.end();
                           })
@@ -444,15 +450,18 @@ exports.updateReview = function(req, res) {
 exports.deleteReview = function(req, res) {
   var restaurantReviews;
   var aggregateRatings;
-  var restaurantName;
   var servicePath;
-  utils.getListByType('Review', req.params.id, req.headers)
+  var restaurantName;
+  var restaurantId;
+  var reviewId = utils.nameToId(req.params.id);
+  utils.getListByType('Review', reviewId, req.headers)
     .then(function(data) {
-      restaurantName = data.body.itemReviewed.name;
-      utils.getListByType('Restaurant', restaurantName, req.headers)
+      restaurantName = data.body.itemReviewed;
+      restaurantId = utils.nameToId(restaurantName);
+      utils.getListByType('Restaurant', restaurantId, req.headers)
         .then(function(data) {
           servicePath = data.body.department;
-          utils.sendRequest('DELETE', null, req.params.id, req.headers)
+          utils.sendRequest('DELETE', null, reviewId, req.headers)
             .then(function(data) {
               utils.getListByType('Review', null, req.headers)
                 .then(function(data) {
@@ -463,7 +472,7 @@ exports.deleteReview = function(req, res) {
                     restaurantReviews);
                   req.headers['fiware-servicepath'] = '/' + servicePath;
                   utils.sendRequest('PATCH', aggregateRatings,
-                      restaurantName, req.headers)
+                      restaurantId, req.headers)
                     .then(function(data) {
                       res.end();
                     })
@@ -569,11 +578,12 @@ exports.createReservation = function(req, res) {
   var capacity;
   var actualOccupancyLevels;
   var timeframeQuery;
+  var restaurantId = utils.nameToId(req.body.reservationFor.name);
   var valid = tv4.validate(req.body, 'reservation');
   if (valid) {
     // -- We first get information regarding the restaurant
     utils.getListByType('Restaurant',
-        req.body.reservationFor.name,
+        restaurantId,
         req.headers)
     .then(function(data) {
       elementToOrion = req.body;
@@ -649,8 +659,9 @@ exports.createReservation = function(req, res) {
 };
 
 exports.readReservation = function(req, res) {
+  var reservationId = utils.nameToId(req.params.id);
   utils.getListByType('FoodEstablishmentReservation',
-                      req.params.id,
+                      reservationId,
                       req.headers)
     .then(function(data) {
       res.statusCode = data.statusCode;
@@ -665,8 +676,9 @@ exports.readReservation = function(req, res) {
 exports.updateReservation = function(req, res) {
   var restaurantName;
   var userId;
+  var reservationId = utils.nameToId(req.params.id);
   utils.getListByType('FoodEstablishmentReservation',
-                      req.params.id,
+                      reservationId,
                       req.headers)
   .then(function(data) {
     userId = data.body.underName.name;
@@ -709,7 +721,8 @@ exports.updateReservation = function(req, res) {
 };
 
 exports.deleteReservation = function(req, res) {
-  utils.sendRequest('DELETE', null, req.params.id, req.headers)
+  var reservationId = utils.nameToId(req.params.id);
+  utils.sendRequest('DELETE', null, reservationId, req.headers)
     .then(function(data) {
       res.statusCode = data.statusCode;
       res.end();

--- a/server/routes/orion.js
+++ b/server/routes/orion.js
@@ -86,8 +86,8 @@ exports.readRestaurant = function(req, res) {
   var occupancyLevelsObject;
   var restaurant;
   var fiwareHeaders;
-  var actualDate = new Date().getTime();
   var restaurantId = utils.nameToId(req.params.id);
+  var actualDate = new Date().toISOString();
   timeframeQuery = utils.getTimeframe(actualDate);
   utils.sendRequest('GET', {
         'type': 'FoodEstablishmentReservation',
@@ -120,7 +120,7 @@ exports.readRestaurant = function(req, res) {
               utils.getListByType('Restaurant', restaurantId, req.headers)
                 .then(function(data) {
                   res.statusCode = data.statusCode;
-                  res.json(utils.dataToSchema(data.body));
+                  res.json(utils.dataToSchema(data.body, actualDate));
                 })
                 .catch(function(err) {
                   res.statusCode = err.statusCode;
@@ -183,7 +183,7 @@ exports.readRestaurantWithDate = function(req, res) {
               utils.getListByType('Restaurant', restaurantId, req.headers)
                 .then(function(data) {
                   res.statusCode = data.statusCode;
-                  res.json(utils.dataToSchema(data.body));
+                  res.json(utils.dataToSchema(data.body, req.params.date));
                 })
                 .catch(function(err) {
                   res.statusCode = err.statusCode;

--- a/server/routes/orion.js
+++ b/server/routes/orion.js
@@ -587,7 +587,7 @@ exports.createReservation = function(req, res) {
         req.headers)
     .then(function(data) {
       elementToOrion = req.body;
-      elementToOrion.reservationFor.address = data.body.address;
+      elementToOrion.address = data.body.address;
       capacity = data.body.capacity.value;
       timeframeQuery = utils.getTimeframe(req.body.startTime);
       utils.sendRequest('GET', {
@@ -681,7 +681,7 @@ exports.updateReservation = function(req, res) {
                       reservationId,
                       req.headers)
   .then(function(data) {
-    userId = data.body.underName.name;
+    userId = data.body.underName;
     auth.getUserDataPromise(req)
     .then(function(data) {
       if (userId !== data.id) {

--- a/server/routes/orion.js
+++ b/server/routes/orion.js
@@ -207,7 +207,12 @@ exports.readRestaurantWithDate = function(req, res) {
 };
 
 exports.updateRestaurant = function(req, res) {
-  utils.sendRequest('PATCH', req.body, req.params.id, req.headers)
+  var restaurantId = utils.nameToId(req.params.id);
+  utils.sendRequest('PATCH',
+                    req.body,
+                    restaurantId,
+                    req.headers,
+                    {'options': 'keyValues'})
     .then(function(data) {
       res.statusCode = data.statusCode;
       res.end();
@@ -376,8 +381,8 @@ exports.updateReview = function(req, res) {
               fixedReviewObject.reviewBody = utils.fixedEncodeURIComponent(
                 fixedReviewObject.reviewBody);
             }
-            utils.sendRequest('PATCH', fixedReviewObject, req.params.id,
-                req.headers)
+            utils.sendRequest('PATCH', fixedReviewObject, reviewId,
+                req.headers, {'options': 'keyValues'})
               .then(function(data) {
                 var fwHeaders = JSON.parse(JSON.stringify(req.headers));
                 if (typeof fwHeaders['fiware-servicepath'] !==
@@ -677,7 +682,11 @@ exports.updateReservation = function(req, res) {
           }
         });
       } else {
-        utils.sendRequest('PATCH', req.body, req.params.id, req.headers)
+        utils.sendRequest('PATCH',
+                          req.body,
+                          reservationId,
+                          req.headers,
+                          {'options': 'keyValues'})
         .then(function(data) {
           res.statusCode = data.statusCode;
           res.end();

--- a/server/schema/schema.js
+++ b/server/schema/schema.js
@@ -1,190 +1,203 @@
 /*
- * schema.js
- * Copyright(c) 2016 Bitergia
- * Author: Bitergia <fiware-testing@bitergia.com>
- * MIT Licensed
- *
- * Schema types definition
- *
- */
+* schema.js
+* Copyright(c) 2016 Bitergia
+* Author: Bitergia <fiware-testing@bitergia.com>
+* MIT Licensed
+*
+* Schema types definition
+*
+*/
 
 // jshint node: true
 module.exports.restaurant = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
-    'title': 'Restaurant',
-    'description': 'A restaurant model',
-    'type': 'object',
-    'properties': {
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'title': 'Restaurant',
+  'description': 'A restaurant model',
+  'type': 'object',
+  'properties': {
+    '@type': {
+      'description': 'Type of the restaurant',
+      'type': 'string'
+    },
+    'name': {
+      'description': 'Name of the restaurant',
+      'type': 'string'
+    },
+    'address': {
+      'type': 'object',
+      'properties': {
         '@type': {
-            'description': 'Type of the restaurant',
-            'type': 'string'
+          'type': 'string'
+        },
+        'streetAddress': {
+          'type': 'string'
+        },
+        'addressLocality': {
+          'type': 'string'
+        },
+        'addressRegion': {
+          'type': 'string'
+        },
+        'postalCode': {
+          'type': 'number'
+        }
+      },
+      'minItems': 1,
+      'uniqueItems': true
+    },
+    'department': {
+      'type': 'string'
+    },
+    'description': {
+      'type': 'string'
+    },
+    'priceRange': {
+      'type': 'number',
+      'minimum': 0,
+      'exclusiveMinimum': true
+    },
+    'telephone': {
+      'type': 'string'
+    },
+    'url': {
+      'type': 'string'
+    },
+    'capacity': {
+      'type': 'object',
+      'properties': {
+        'type': {
+          'type': 'string'
         },
         'name': {
-            'description': 'Name of the restaurant',
-            'type': 'string'
+          'type': 'string'
         },
-        'address': {
-            'type': 'object',
-            'properties': {
-                '@type': {
-                  'type': 'string'
-                },
-                'streetAddress': {
-                  'type': 'string'
-                },
-                'addressLocality': {
-                  'type': 'string'
-                },
-                'addressRegion': {
-                  'type': 'string'
-                },
-                'postalCode': {
-                  'type': 'number'
-                }
+        'value': {
+          'type': 'number'
+        }
+      },
+      'minItems': 1,
+      'uniqueItems': true
+    },
+    'occupancyLevels': {
+      'type': 'object',
+      'properties': {
+        'type': {
+          'type': 'string'
+        },
+        'metadata': {
+          'type': 'object',
+          'properties': {
+            'type': {
+              'type': 'string'
             },
-            'minItems': 1,
-            'uniqueItems': true
-        },
-        'department': {
-            'type': 'string'
-        },
-        'description': {
-            'type': 'string'
-        },
-        'priceRange': {
-            'type': 'number',
-            'minimum': 0,
-            'exclusiveMinimum': true
-        },
-        'telephone': {
-            'type': 'string'
-        },
-        'url': {
-            'type': 'string'
-        },
-        'capacity': {
-            'type': 'object',
-            'properties': {
+            'timestamp': {
+              'type': 'object',
+              'properties': {
                 'type': {
-                  'type': 'string'
-                },
-                'name': {
                   'type': 'string'
                 },
                 'value': {
-                  'type': 'number'
-                }
-            },
-            'minItems': 1,
-            'uniqueItems': true
-        },
-        'occupancyLevels': {
-            'type': 'object',
-            'properties': {
-                'type': {
-                  'type': 'string'
-                },
-                'timestamp': {
                   'type': 'string',
                   // jshint maxlen: false
                   // jscs:disable maximumLineLength
                   'pattern': '/[0-9]{4,}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+|)(?:[+-][0-9]{2}:[0-9]{2}|Z)/'
                   // jshint maxlen: 80
                   // jscs:enable
-                },
-                'name': {
-                  'type': 'string'
-                },
-                'value': {
-                  'type': 'number'
                 }
-            },
-            'minItems': 1,
-            'uniqueItems': true
+              }
+            }
+          }
+        },
+        'value': {
+          'type': 'number'
         }
-    },
-    'required': ['@type', 'name', 'address', 'department',
-    'description', 'priceRange',
-    'telephone', 'url', 'capacity', 'occupancyLevels']
+      },
+      'minItems': 1,
+      'uniqueItems': true
+    }
+  },
+  'required': ['@type', 'name', 'address', 'department',
+  'description', 'priceRange',
+  'telephone', 'url', 'capacity', 'occupancyLevels']
 };
 
 module.exports.reservation = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
-    'title': 'Reservation',
-    'description': 'A reservation model',
-    'type': 'object',
-    'properties': {
-        '@type': {
-            'description': 'Type of the reservation',
-            'type': 'string'
-        },
-        'partySize': {
-            'type': 'number'
-        },
-        'startTime': {
-            'type': 'string',
-            // jshint maxlen: false
-            // jscs:disable maximumLineLength
-            'pattern': '/[0-9]{4,}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+|)(?:[+-][0-9]{2}:[0-9]{2}|Z)/'
-            // jshint maxlen: 80
-            // jscs:enable
-        },
-        'reservationFor': {
-            'type': 'object',
-            'properties': {
-                '@type': {
-                  'type': 'string'
-                },
-                'name': {
-                  'type': 'string'
-                }
-            },
-            'minItems': 1,
-            'uniqueItems': true
-        }
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'title': 'Reservation',
+  'description': 'A reservation model',
+  'type': 'object',
+  'properties': {
+    '@type': {
+      'description': 'Type of the reservation',
+      'type': 'string'
     },
-    'required': ['@type', 'partySize', 'startTime', 'reservationFor']
+    'partySize': {
+      'type': 'number'
+    },
+    'startTime': {
+      'type': 'string',
+      // jshint maxlen: false
+      // jscs:disable maximumLineLength
+      'pattern': '/[0-9]{4,}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+|)(?:[+-][0-9]{2}:[0-9]{2}|Z)/'
+      // jshint maxlen: 80
+      // jscs:enable
+    },
+    'reservationFor': {
+      'type': 'object',
+      'properties': {
+        '@type': {
+          'type': 'string'
+        },
+        'name': {
+          'type': 'string'
+        }
+      },
+      'minItems': 1,
+      'uniqueItems': true
+    }
+  },
+  'required': ['@type', 'partySize', 'startTime', 'reservationFor']
 };
 
 module.exports.review = {
-    '$schema': 'http://json-schema.org/draft-04/schema#',
-    'title': 'Review',
-    'description': 'A review model',
-    'type': 'object',
-    'properties': {
-        '@type': {
-            'description': 'Type of the review',
-            'type': 'string'
-        },
-        'itemReviewed': {
-            'type': 'object',
-            'properties': {
-                '@type': {
-                  'type': 'string'
-                },
-                'name': {
-                  'type': 'string'
-                }
-            },
-            'minItems': 1,
-            'uniqueItems': true
-        },
-        'reviewRating': {
-            'type': 'object',
-            'properties': {
-                '@type': {
-                  'type': 'string'
-                },
-                'ratingValue': {
-                  'type': 'number'
-                }
-            },
-            'minItems': 1,
-            'uniqueItems': true
-        },
-        'reviewBody': {
-            'type': 'string'
-        }
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'title': 'Review',
+  'description': 'A review model',
+  'type': 'object',
+  'properties': {
+    '@type': {
+      'description': 'Type of the review',
+      'type': 'string'
     },
-    'required': ['@type', 'itemReviewed', 'reviewRating', 'reviewBody']
+    'itemReviewed': {
+      'type': 'object',
+      'properties': {
+        '@type': {
+          'type': 'string'
+        },
+        'name': {
+          'type': 'string'
+        }
+      },
+      'minItems': 1,
+      'uniqueItems': true
+    },
+    'reviewRating': {
+      'type': 'object',
+      'properties': {
+        '@type': {
+          'type': 'string'
+        },
+        'ratingValue': {
+          'type': 'number'
+        }
+      },
+      'minItems': 1,
+      'uniqueItems': true
+    },
+    'reviewBody': {
+      'type': 'string'
+    }
+  },
+  'required': ['@type', 'itemReviewed', 'reviewRating', 'reviewBody']
 };

--- a/server/spec/reservationsspec.js
+++ b/server/spec/reservationsspec.js
@@ -17,7 +17,7 @@ var config = require('../config');
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var oauthTokenUrl = config.idmUrl + '/oauth2/token';
-var username = 'user0@test.com';
+var username = 'user1@test.com';
 var password = 'test';
 var reservationDate = '2015-12-24T10:12:23.396Z';
 var auth = 'Basic ' +
@@ -111,7 +111,7 @@ frisby.create('OAuth2 login')
 
         frisby.create('Patch a Reservation')
           .patch('http://tourguide' + location, {
-            'partySize': '10'
+            'partySize': 10
           }, {
             json: true
           })

--- a/server/spec/restaurantsspec.js
+++ b/server/spec/restaurantsspec.js
@@ -58,15 +58,18 @@ frisby.create('OAuth2 login')
         'telephone': '912345678',
         'url': 'http://www.example.com',
         'capacity': {
-          'type': 'PropertyValue',
-          'name': 'capacity',
+          '@type': 'PropertyValue',
           'value': 200
         },
         'occupancyLevels': {
-          'type': 'PropertyValue',
-          'timestamp': new Date().toISOString(),
-          'name': 'occupancyLevels',
-          'value': 0
+          '@type': 'PropertyValue',
+          'value': 0,
+          'metadata': {
+            'timestamp': {
+              '@type': 'date',
+              'value': new Date().toISOString()
+            }
+          }
         }
       }, {
         json: true

--- a/server/spec/reviewsspec.js
+++ b/server/spec/reviewsspec.js
@@ -18,7 +18,7 @@ var config = require('../config');
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var oauthTokenUrl = config.idmUrl + '/oauth2/token';
-var username = 'user0@test.com';
+var username = 'user2@test.com';
 var password = 'test';
 var auth = 'Basic ' +
   new Buffer(config.clientId + ':' + config.clientSecret).toString('base64');
@@ -87,7 +87,7 @@ frisby.create('OAuth2 login')
 
         frisby.create('Patch a Review')
           .patch('http://tourguide' + location, {
-            'reviewBody': 'Patch done!\n'
+            'reviewBody': 'Patch done!'
           }, {
             json: true
           })

--- a/server/utils.js
+++ b/server/utils.js
@@ -464,39 +464,42 @@ function dataToSchema(listOfElements) {
 }
 
 function fixAddress(schemaObject, geoObject) {
+  // The returned object will be POST/PATCH(ed),
+  // so we need to add the 'value' field
   if (geoObject) {
     if (geoObject.streetName && geoObject.streetNumber) {
-      schemaObject.address.streetAddress =
+      schemaObject.address.value.streetAddress =
       geoObject.streetName +
       ' ' + geoObject.streetNumber;
     } else if (geoObject.streetName) {
-      schemaObject.address.streetAddress = geoObject.streetName;
+      schemaObject.address.value.streetAddress = geoObject.streetName;
     }
     if (geoObject.city) {
-      schemaObject.address.addressLocality = geoObject.city;
+      schemaObject.address.value.addressLocality = geoObject.city;
     } else if (geoObject.administrativeLevels.level2long) {
-      schemaObject.address.addressLocality =
+      schemaObject.address.value.addressLocality =
       geoObject.administrativeLevels
       .level2long;
     }
     if (geoObject.administrativeLevels.level2long) {
-      schemaObject.address.addressRegion =
+      schemaObject.address.value.addressRegion =
       geoObject.administrativeLevels
       .level2long;
     }
     if (geoObject.zipcode) {
-      schemaObject.address.postalCode = geoObject.zipcode;
+      schemaObject.address.value.postalCode = geoObject.zipcode;
     }
   }
   return schemaObject;
 }
 
 function addGeolocation(schemaObject, geoObject) {
+  // The returned object will be POST/PATCH(ed),
+  // so we need to add the 'value' field
   if (geoObject) {
-    schemaObject.position = {};
-    schemaObject.position.type = 'coords';
-    schemaObject.position.location = 'WGS84';
-    schemaObject.position.value = geoObject.latitude + ', ' +
+    schemaObject.location = {};
+    schemaObject.location.type = 'geo:point';
+    schemaObject.location.value = geoObject.latitude + ', ' +
       geoObject.longitude;
   }
   return schemaObject;
@@ -674,26 +677,29 @@ function getAverage(data) {
 }
 
 function getAggregateRating(listOfReviews) {
-
+  // The returned object will be POST/PATCH(ed),
+  // so we need to add the 'value' field
   var counter = 0;
   var ratingValues = [];
   var newElement = {
-    'aggregateRating': {}
+    'aggregateRating': {
+      'value': {}
+    }
   };
 
   listOfReviews = objectToArray(listOfReviews);
 
   Object.keys(listOfReviews).forEach(function(element, pos) {
 
-    if (listOfReviews[pos].reviewRating.ratingValue !== undefined) {
+    if (listOfReviews[pos].reviewRating !== undefined) {
 
-      ratingValues.push(listOfReviews[pos].reviewRating.ratingValue);
+      ratingValues.push(listOfReviews[pos].reviewRating);
       counter++;
     }
   });
 
-  newElement.aggregateRating.reviewCount = counter;
-  newElement.aggregateRating.ratingValue = getAverage(ratingValues);
+  newElement.aggregateRating.value.reviewCount = counter;
+  newElement.aggregateRating.value.ratingValue = getAverage(ratingValues);
 
   return newElement;
 }
@@ -752,9 +758,13 @@ function getTimeBetweenDates(from, to) {
 function updateOccupancyLevels(occupancyLevel, date) {
   return {
     'occupancyLevels': {
+      'metadata': {
+        'timestamp': {
+          'type': 'date',
+          'value': date
+        }
+      },
       'type': 'PropertyValue',
-      'timestamp': date,
-      'name': 'occupancyLevels',
       'value': occupancyLevel
     }
   };

--- a/server/utils.js
+++ b/server/utils.js
@@ -580,7 +580,7 @@ function getOrgRestaurants(org, listOfElements) {
 function getUserReviews(user, listOfElements) {
   return objectToArray(listOfElements).filter(
     function(element) {
-      return element.author.name === user;
+      return element.author === user;
     }
   );
 }
@@ -589,7 +589,7 @@ function getUserReviews(user, listOfElements) {
 function getRestaurantReviews(restaurant, listOfElements) {
   return objectToArray(listOfElements).filter(
     function(element) {
-      return element.itemReviewed.name === restaurant;
+      return element.itemReviewed === restaurant;
     }
   );
 }
@@ -597,13 +597,13 @@ function getRestaurantReviews(restaurant, listOfElements) {
 // filter reviews by organization
 function getOrgReviews(franchise, listOfRestaurants, listOfReviews) {
   // list of restaurants of the franchise
-  listOfRestaurants = getOrgRestaurants(franchise,listOfRestaurants);
+  listOfRestaurants = getOrgRestaurants(franchise, listOfRestaurants);
 
   // filter reviews of the restaurants of the franchise
   return objectToArray(listOfReviews).filter(
     function(element) {
       return listOfRestaurants.some(function(restaurant) {
-        return restaurant.id === element.itemReviewed.name;
+        return restaurant.name === element.itemReviewed;
       });
     }
   );
@@ -613,7 +613,7 @@ function getOrgReviews(franchise, listOfRestaurants, listOfReviews) {
 function getUserReservations(user, listOfElements) {
   return objectToArray(listOfElements).filter(
     function(element) {
-      return element.underName.name === user;
+      return element.underName === user;
     }
   );
 }
@@ -622,7 +622,7 @@ function getUserReservations(user, listOfElements) {
 function getRestaurantReservations(restaurant, listOfElements) {
   return objectToArray(listOfElements).filter(
     function(element) {
-      return element.reservationFor.name === restaurant;
+      return element.reservationFor === restaurant;
     }
   );
 }
@@ -635,7 +635,7 @@ function getOrgReservations(franchise, listOfRestaurants, listOfReservations) {
   return objectToArray(listOfReservations).filter(
     function(element) {
       return listOfRestaurants.some(function(restaurant) {
-        return restaurant.id === element.reservationFor.name;
+        return restaurant.name === element.reservationFor;
       });
     }
   );

--- a/server/utils.js
+++ b/server/utils.js
@@ -507,15 +507,63 @@ function addGeolocation(schemaObject, geoObject) {
 
 function restaurantToOrion(schemaObject, geoObject) {
 
-  schemaObject = replaceTypeForOrion(schemaObject);
-  schemaObject.id = schemaObject.name;
-  delete schemaObject.name;
+  var objectToOrion = {
+    'address': {
+      'type': 'PostalAddress',
+      'value': {
+        'streetAddress': schemaObject.address.streetAddress,
+        'addressLocality': schemaObject.address.addressLocality,
+        'addressRegion': schemaObject.address.addressRegion,
+        'postalCode': schemaObject.address.postalCode
+      }
+    },
+    'aggregateRating': {
+      'type': 'AggregateRating',
+      'value': {
+        'ratingValue': 0,
+        'reviewCount': 0
+      }
+    },
+    'capacity': {
+      'type': 'PropertyValue',
+      'value': schemaObject.capacity.value
+    },
+    'department': {
+      'value': schemaObject.department
+    },
+    'description': {
+      'value': schemaObject.description
+    },
+    'id': asciiEncode(stripForbiddenChars(schemaObject.name)),
+    'name': {
+      'value': fixedEncodeURIComponent(schemaObject.name)
+    },
+    'priceRange': {
+      'value': schemaObject.priceRange
+    },
+    'telephone': {
+      'value': schemaObject.telephone
+    },
+    'occupancyLevels': {
+      'metadata': {
+        'timestamp': {
+          'type': 'date',
+          'value': schemaObject.occupancyLevels.metadata.timestamp.value
+        }
+      },
+      'type': 'PropertyValue',
+      'value': schemaObject.occupancyLevels.value
+    },
+    'type': 'Restaurant',
+    'url': {
+      'value': schemaObject.url
+    },
+  };
 
-  schemaObject = addGeolocation(schemaObject, geoObject);
-  schemaObject = fixAddress(schemaObject, geoObject);
+  objectToOrion = addGeolocation(objectToOrion, geoObject);
+  objectToOrion = fixAddress(objectToOrion, geoObject);
 
-  return sortObject(schemaObject);
-
+  return sortObject(objectToOrion);
 }
 
 function reviewToOrion(userObject, schemaObject) {

--- a/server/utils.js
+++ b/server/utils.js
@@ -339,43 +339,32 @@ function reviewToSchema(element) {
 
 function reservationToSchema(element) {
 
-  var reservationSchemaElements = [
-    'reservationStatus',
-    'underName',
-    'reservationFor',
-    'startTime',
-    'partySize'
-  ];
-
-  var newElement = {
-    '@context': 'http://schema.org',
-    '@type': element.type
-  };
-
-  var val;
-
-  Object.keys(element).forEach(function(elementAttribute) {
-    val = element[elementAttribute];
-    if (reservationSchemaElements.indexOf(elementAttribute) !==
-      -1) {
-      if (val !== 'undefined') {
-        if (typeof val === 'string') {
-          newElement[elementAttribute] = unescape(val);
-        } else {
-          newElement[elementAttribute] = val;
+  var elementToSchema = {
+      '@context': 'http://schema.org',
+      '@type': 'FoodEstablishmentReservation',
+      'partySize': element.partySize,
+      'reservationFor': {
+        '@type': 'FoodEstablishment',
+        'name': element.reservationFor,
+        'address': {
+          '@type': 'postalAddress',
+          'streetAddress': element.address.streetAddress,
+          'addressRegion': element.address.addressRegion,
+          'addressLocality': element.address.addressLocality,
+          'postalCode': element.address.postalCode,
         }
-      }
-    }
-  });
-  var newDate = new Date(newElement.startTime).toISOString();
-  newElement.startTime = newDate;
-  newElement.reservationId = unescape(element.id);
-  newElement.reservationFor.name = unescape(
-    newElement.reservationFor.name);
+      },
+      'reservationStatus': element.reservationStatus,
+      'startTime': element.startTime,
+      'underName': {
+        '@type': 'Person',
+        'name': element.underName
+      },
+      'reservationId': unescape(element.id)
+    };
 
-  newElement = replaceTypeForSchema(newElement);
+  return sortObject(elementToSchema);
 
-  return newElement;
 }
 
 function objectDataToSchema(element, date) {

--- a/server/utils.js
+++ b/server/utils.js
@@ -568,29 +568,37 @@ function restaurantToOrion(schemaObject, geoObject) {
 
 function reviewToOrion(userObject, schemaObject) {
 
-  // -- TODO: check how to implement 'position field'
-  // -- - idea is, whenever a new review is created into
-  // -- - a restaurant, the review position increase;
-  // -- - but the only one able to modify it is the user
-  // -- - We need that way cause we cannot display 'ids'
-
   if (userObject) {
-    schemaObject = replaceTypeForOrion(schemaObject);
-    var rname = schemaObject.itemReviewed.name;
-    rname += '-' + shortid.generate();
-    schemaObject.id = rname;
-    schemaObject.reviewBody = fixedEncodeURIComponent(schemaObject.reviewBody);
-    schemaObject.author = {};
-    schemaObject.author.type = 'Person';
-    schemaObject.author.name = userObject.id;
-    schemaObject.dateCreated = new Date().getTime();
-    if (userObject.organizations[0]) {
-      schemaObject.publisher = {};
-      schemaObject.publisher.type = 'Organization';
-      schemaObject.publisher.name = userObject.organizations[0].name;
-    }
+    var reviewId = schemaObject.itemReviewed.name += '-' + shortid.generate();
+    var objectToOrion = {
+      'author': {
+        'type': 'Person',
+        'value': userObject.id
+      },
+      'dateCreated': {
+        'type': 'date',
+        'value': new Date().toISOString()
+      },
+      'id': asciiEncode(reviewId),
+      'itemReviewed': {
+        'type': 'Restaurant',
+        'value': fixedEncodeURIComponent(schemaObject.itemReviewed.name)
+      },
+      'publisher': {
+        'type': 'Organization',
+        'value': userObject.organizations[0].name
+      },
+      'reviewRating': {
+        'type': 'Rating',
+        'value': schemaObject.reviewRating.ratingValue
+      },
+      'reviewBody': {
+        'value': fixedEncodeURIComponent(schemaObject.reviewBody)
+      },
+      'type': 'Review'
+    };
+    return sortObject(objectToOrion);
   }
-  return sortObject(schemaObject);
 }
 
 function reservationToOrion(userObject, schemaObject) {

--- a/server/utils.js
+++ b/server/utils.js
@@ -534,7 +534,7 @@ function restaurantToOrion(schemaObject, geoObject) {
     'description': {
       'value': schemaObject.description
     },
-    'id': asciiEncode(stripForbiddenChars(schemaObject.name)),
+    'id': nameToId(schemaObject.name),
     'name': {
       'value': fixedEncodeURIComponent(schemaObject.name)
     },
@@ -569,7 +569,7 @@ function restaurantToOrion(schemaObject, geoObject) {
 function reviewToOrion(userObject, schemaObject) {
 
   if (userObject) {
-    var reviewId = schemaObject.itemReviewed.name += '-' + shortid.generate();
+    var reviewId = schemaObject.itemReviewed.name + '-' + shortid.generate();
     var objectToOrion = {
       'author': {
         'type': 'Person',
@@ -579,7 +579,7 @@ function reviewToOrion(userObject, schemaObject) {
         'type': 'date',
         'value': new Date().toISOString()
       },
-      'id': asciiEncode(reviewId),
+      'id': nameToId(reviewId),
       'itemReviewed': {
         'type': 'Restaurant',
         'value': fixedEncodeURIComponent(schemaObject.itemReviewed.name)
@@ -604,9 +604,10 @@ function reviewToOrion(userObject, schemaObject) {
 function reservationToOrion(userObject, schemaObject) {
 
   if (userObject) {
-    var reservationId = schemaObject.reservationFor.name += '-' + shortid.generate();
+    var reservationId = schemaObject.reservationFor.name +
+    '-' + shortid.generate();
     var objectToOrion = {
-      'id': asciiEncode(reservationId),
+      'id': nameToId(reservationId),
       'partySize': {
         'value': schemaObject.partySize
       },
@@ -880,6 +881,10 @@ function stripForbiddenChars(str) {
   return str;
 }
 
+function nameToId(name) {
+  return asciiEncode(stripForbiddenChars(name));
+}
+
 module.exports = {
   doGet: doGet,
   doPost: doPost,
@@ -919,5 +924,6 @@ module.exports = {
   getTimeBetweenDates: getTimeBetweenDates,
   updateOccupancyLevels: updateOccupancyLevels,
   asciiEncode: asciiEncode,
-  stripForbiddenChars: stripForbiddenChars
+  stripForbiddenChars: stripForbiddenChars,
+  nameToId: nameToId
 };

--- a/server/utils.js
+++ b/server/utils.js
@@ -722,17 +722,27 @@ function getListByType(type, element, headers) {
   );
 }
 
-function sendRequest(method, body, identifier, headers) {
+function sendRequest(method, body, identifier, headers, payload) {
   var uri = '/v2/entities';
   if (identifier) {
     uri += '/' + encodeURIComponent(identifier);
   }
-  return authRequest(
-    uri,
-    method,
-    body,
-    headers
-  );
+  if (typeof payload === 'undefined') {
+    return authRequest(
+      uri,
+      method,
+      body,
+      headers
+    );
+  } else {
+    return authRequest(
+      uri,
+      method,
+      body,
+      headers,
+      payload
+    );
+  }
 }
 
 function getAverage(data) {

--- a/server/utils.js
+++ b/server/utils.js
@@ -310,42 +310,31 @@ function restaurantToSchema(element, date) {
 
 function reviewToSchema(element) {
 
-  var reviewSchemaElements = [
-    'itemReviewed',
-    'reviewRating',
-    'name',
-    'author',
-    'reviewBody',
-    'publisher',
-    'dateCreated'
-  ];
-
-  var newElement = {
+  var elementToSchema = {
     '@context': 'http://schema.org',
-    '@type': element.type
+    '@type': 'Review',
+    'author': {
+      '@type': 'Person',
+      'name': element.author
+    },
+    'dateCreated': element.dateCreated,
+    'itemReviewed': {
+      '@type': 'Restaurant',
+      'name': element.itemReviewed
+    },
+    'name': unescape(element.id),
+    'publisher': {
+      '@type': 'Organization',
+      'name': element.publisher
+    },
+    'reviewBody': element.reviewBody,
+    'reviewRating': {
+      '@type': 'Rating',
+      'ratingValue': element.reviewRating
+    }
   };
 
-  var val;
-
-  Object.keys(element).forEach(function(elementAttribute) {
-      val = element[elementAttribute];
-      if (reviewSchemaElements.indexOf(elementAttribute) !== -1) {
-        if (val !== 'undefined') {
-          if (typeof val === 'string') {
-            newElement[elementAttribute] = unescape(val);
-          } else {
-            newElement[elementAttribute] = val;
-          }
-        }
-      }
-    });
-
-  var newDate = new Date(newElement.dateCreated).toISOString();
-  newElement.dateCreated = newDate;
-  newElement.name = unescape(element.id);
-  newElement = replaceTypeForSchema(newElement);
-
-  return newElement;
+  return sortObject(elementToSchema);
 }
 
 function reservationToSchema(element) {

--- a/server/utils.js
+++ b/server/utils.js
@@ -760,6 +760,33 @@ function updateOccupancyLevels(occupancyLevel, date) {
   };
 }
 
+function asciiEncode(string) {
+
+  var escapable = /[\\\"\x00-\x1f\x7f-\uffff]/g;
+  var meta = { // table of character substitutions
+    '\b': '\\b',
+    '\t': '\\t',
+    '\n': '\\n',
+    '\f': '\\f',
+    '\r': '\\r',
+    '"': '\\"',
+    '\\': '\\\\'
+  };
+
+  escapable.lastIndex = 0;
+  return escapable.test(string) ?
+  string.replace(escapable, function(a) {
+    var c = meta[a];
+    return typeof c === 'string' ? c :
+    '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+  }) : string ;
+}
+
+function stripForbiddenChars(str) {
+  str = str.replace(/[<>"'=;()&?#\s]/g, '_');
+  return str;
+}
+
 module.exports = {
   doGet: doGet,
   doPost: doPost,
@@ -797,5 +824,7 @@ module.exports = {
   getTimeframe: getTimeframe,
   getOccupancyLevels: getOccupancyLevels,
   getTimeBetweenDates: getTimeBetweenDates,
-  updateOccupancyLevels: updateOccupancyLevels
+  updateOccupancyLevels: updateOccupancyLevels,
+  asciiEncode: asciiEncode,
+  stripForbiddenChars: stripForbiddenChars
 };

--- a/server/utils.js
+++ b/server/utils.js
@@ -603,24 +603,36 @@ function reviewToOrion(userObject, schemaObject) {
 
 function reservationToOrion(userObject, schemaObject) {
 
-  // -- TODO: check automatically if there's enough space at
-  // -- the restaurant, so reservation is accepted automatically
-
   if (userObject) {
-    schemaObject = replaceTypeForOrion(schemaObject);
-    var rname = schemaObject.reservationFor.name;
-    rname += '-' + shortid.generate();
-    schemaObject.id = rname;
-    var newDate = new Date(schemaObject.startTime).getTime();
-    //Time in miliseconds to Orion
-    schemaObject.startTime = newDate;
-    schemaObject.underName = {};
-    schemaObject.partySize = parseInt(schemaObject.partySize, 10);
-    schemaObject.underName.type = 'Person';
-    schemaObject.underName.name = userObject.id;
-    schemaObject.reservationStatus = 'Confirmed';
+    var reservationId = schemaObject.reservationFor.name += '-' + shortid.generate();
+    var objectToOrion = {
+      'id': asciiEncode(reservationId),
+      'partySize': {
+        'value': schemaObject.partySize
+      },
+      'reservationFor': {
+        'type': 'FoodEstablishment',
+        'value': fixedEncodeURIComponent(schemaObject.reservationFor.name)
+      },
+      'reservationStatus': {
+        'value': 'Confirmed'
+      },
+      'startTime': {
+        'type': 'date',
+        'value': new Date(schemaObject.startTime).toISOString()
+      },
+      'address': {
+        'type': 'PostalAddress',
+        'value': schemaObject.address
+      },
+      'type': 'FoodEstablishmentReservation',
+      'underName': {
+        'type': 'Person',
+        'value': userObject.id
+      }
+    };
+    return sortObject(objectToOrion);
   }
-  return sortObject(schemaObject);
 }
 
 // filter restaurants by organization

--- a/server/utils.js
+++ b/server/utils.js
@@ -794,28 +794,6 @@ function getAggregateRating(listOfReviews) {
   return newElement;
 }
 
-function replaceTypeForOrion(schemaObject) {
-  var parsed = JSON.parse(JSON.stringify(schemaObject), function(key, value) {
-    if (key === '@type') {
-      this.type = value;
-    } else {
-      return value;
-    }
-  });
-  return parsed;
-}
-
-function replaceTypeForSchema(element) {
-  var parsed = JSON.parse(JSON.stringify(element), function(key, value) {
-    if (key === 'type') {
-      this['@type'] = value;
-    } else {
-      return value;
-    }
-  });
-  return parsed;
-}
-
 function getTimeframe(isoTimeString) {
   var newDate = new Date(isoTimeString);
   var frame = newDate.getTime() - 60 * 60 * 2 * 1000;
@@ -925,8 +903,6 @@ module.exports = {
   sendRequest: sendRequest,
   getAverage: getAverage,
   getAggregateRating: getAggregateRating,
-  replaceTypeForOrion: replaceTypeForOrion,
-  replaceTypeForSchema: replaceTypeForSchema,
   getTimeframe: getTimeframe,
   getOccupancyLevels: getOccupancyLevels,
   getTimeBetweenDates: getTimeBetweenDates,

--- a/server/utils.js
+++ b/server/utils.js
@@ -709,15 +709,20 @@ function getOrgReservations(franchise, listOfRestaurants, listOfReservations) {
   );
 }
 
-function getListByType(type, element, headers) {
+function getListByType(type, element, headers, raw) {
   var uri = '/v2/entities';
+  var options = {'type': type,'limit': '1000'};
   if (element) {
     uri += '/' + encodeURIComponent(element);
+  }
+
+  if (typeof raw === 'undefined') {
+    options.options = 'keyValues';
   }
   return authRequest(
     uri,
     'GET',
-    {'type': type,'limit': '1000'},
+    options,
     headers
   );
 }

--- a/server/utils.js
+++ b/server/utils.js
@@ -399,7 +399,7 @@ function reservationToSchema(element) {
   return newElement;
 }
 
-function objectDataToSchema(element) {
+function objectDataToSchema(element, date) {
 
   var newElement;
   var type = element.type;
@@ -408,7 +408,11 @@ function objectDataToSchema(element) {
 
   case 'Restaurant':
 
-    newElement = restaurantToSchema(element);
+    if (typeof date !== 'undefined') {
+      newElement = restaurantToSchema(element, date);
+    } else {
+      newElement = restaurantToSchema(element);
+    }
     return newElement;
 
   case 'Review':
@@ -446,7 +450,7 @@ function sortObject(element) {
   return sorted;
 }
 
-function dataToSchema(listOfElements) {
+function dataToSchema(listOfElements, date) {
 
   var newListOfElements = [];
   var newElement;
@@ -454,12 +458,14 @@ function dataToSchema(listOfElements) {
   listOfElements = objectToArray(listOfElements);
 
   Object.keys(listOfElements).forEach(function(element, pos) {
-
-    newElement = objectDataToSchema(listOfElements[pos]);
+    if (typeof date !== 'undefined') {
+      newElement = objectDataToSchema(listOfElements[pos], date);
+    } else {
+      newElement = objectDataToSchema(listOfElements[pos]);
+    }
     newListOfElements.push(newElement);
 
   });
-
   return newListOfElements;
 }
 
@@ -811,9 +817,11 @@ function replaceTypeForSchema(element) {
 }
 
 function getTimeframe(isoTimeString) {
-  var newDate = new Date(isoTimeString).getTime();
-  var frame = newDate - 60 * 60 * 2 * 1000;
-  var frameTime = 'startTime==' + frame + '..' + newDate;
+  var newDate = new Date(isoTimeString);
+  var frame = newDate.getTime() - 60 * 60 * 2 * 1000;
+  var frameDateObject = new Date(frame);
+  var frameTime = 'startTime==' + frameDateObject.toISOString() +
+  '..' + newDate.toISOString();
   return frameTime;
 }
 
@@ -833,8 +841,8 @@ function getOccupancyLevels(listOfReservations, restaurant) {
 }
 
 function getTimeBetweenDates(from, to) {
-  var fromTimestamp = new Date(from).getTime();
-  var toTimestamp = new Date(to).getTime();
+  var fromTimestamp = new Date(from).toISOString();
+  var toTimestamp = new Date(to).toISOString();
   var frameTime = 'startTime==' + fromTimestamp + '..' + toTimestamp;
   return frameTime;
 }


### PR DESCRIPTION
Fixes #44 
This PR updates the following:
- Restaurant, review and reservation feeders
- Restaurant, review and reservation input models in the server
- Use 'keyValues' option by default retrieving information from Orion
- Update datetime format to ISO 8601
- Strip/convert forbidden characters from entities id's
- Restaurant, review and reservation models from Orion adapted to Schema.org to not break the client
