### PR TITLE
Use keyrock 5.3.0 official docker image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,25 +19,24 @@ orion:
     command: -dbhost mongodb
 
 authzforce:
-    image: fiware/authzforce-ce-server:release-4.4.1b
+    image: fiware/authzforce-ce-server:release-5.4.0b
     hostname: authzforce
     container_name: authzforce
     expose:
         - "8080"
 
 keyrock:
-    image: bitergia/idm-keyrock:5.1.0
+    image: fiware/idm:v5.3.0
     hostname: keyrock
     container_name: keyrock
     links:
         - authzforce
-    volumes:
-        - /config
     expose:
         - "5000"
-    environment:
-        - APP_NAME=TourGuide
-        - AUTHZFORCE_VERSION=4.4.1b
+        - "8000"
+    ports:
+        - "5000:5000"
+        - "8000:8000"
 
 idas:
     image: fiware/iotagent-ul:develop
@@ -109,9 +108,7 @@ tourguide:
         - IDAS_FIWARE_SERVICE=tourguide
         - IDAS_FIWARE_SERVICE_PATH=/
         - IDAS_API_KEY=tourguide-devices
-        - ORION_SUBSCRIPTIONS_ENABLED=false
-        - SENSORS_GENERATION_ENABLED=false
-        - SENSORS_FORCED_UPDATE_ENABLED=false
         - IDM_HOSTNAME=keyrock
+        - IDM_PORT=8000
     volumes_from:
         - keyrock

--- a/docker/images/tutorials.tourguide-app/Dockerfile
+++ b/docker/images/tutorials.tourguide-app/Dockerfile
@@ -76,9 +76,6 @@ RUN git clone -b ${GIT_REV_TOURGUIDE} ${GIT_URL_TOURGUIDE} && \
 # copy default subscriptions
 COPY cpr-registration.sh ${SUBSCRIPTIONS_PATH}/
 
-# Add provision script for IdM
-COPY keystone_provision.py ${TOURGUIDE_USER_DIR}/keystone_provision.py
-
 # Switch back to root for docker-entrypoint.sh
 USER root
 ADD docker-entrypoint.sh /docker-entrypoint.sh

--- a/server/config.js
+++ b/server/config.js
@@ -4,7 +4,7 @@ var config = {};
 
 // URL to the FI-WARE Identity Management GE
 // default: https://account.lab.fi-ware.org
-config.idmUrl = 'https://IDM_HOSTNAME';
+config.idmUrl = 'http://IDM_HOSTNAME:IDM_PORT';
 
 // Oauth2 configuration
 // Found on the application profile page after registering

--- a/server/setup-test-env.sh
+++ b/server/setup-test-env.sh
@@ -41,6 +41,13 @@ function start_test_env() {
     # start containers with docker-compose
     docker-compose -f "${test_yml}" -p tests up -d
 
+    # provision keyrock
+    pwd
+    ./tour-guide --test configure keyrock -w
+
+    # configure oauth
+    ./tour-guide --test configure oauth -w
+
     # wait for tourguide to be ready
     container_name=$( docker-compose -f "${test_yml}" -p tests ps 2>/dev/null | grep test_tourguide | cut -d ' ' -f 1 )
     while [ ${_started} -eq 0 -a ${_tries} -lt ${_max_tries} ]; do


### PR DESCRIPTION
This PR adds the keyrock 5.3.0 official docker image.  This change depends on the new CLI scipt (#127 and #132), as some configuration steps must be done with it (keyrock provision and tourguide OAuth configuration).

Tests on travis may fail until those changes are merged.
