### PR TITLE
CLI: Add start and stop commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -59,4 +59,8 @@ Check if some required commands (both for running the containers and the scripts
 
 ### start ###
 
+Simple wrapper for docker-compose up.  Allows the user to start the TourGuide-App container and related services.
+
 ### stop ###
+
+Simple wrapper for docker-compose stop/rm.  Allows the user to stop the TourGuide-App container and related services.

--- a/cli/start
+++ b/cli/start
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+#  start
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  start command for TourGuide CLI.
+#
+
+start_service="tourguide"
+
+function module_help () {
+    cat <<EOF >&2
+Usage: ${appname} start [-h | --help] <service>
+
+Start one of the following services and its dependencies:
+
+ * orion
+ * authzforce
+ * keyrock
+ * idas
+ * cygnus
+ * tourguide (default)
+
+Command options:
+
+  -h  --help                 Show this help.
+
+EOF
+    exit 0
+}
+
+function module_options () {
+    TEMP=`getopt -o h -l help -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        module_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                module_help
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        case "$1" in
+            "orion"|"authzforce"|"keyrock"|"idas"|"cygnus")
+                start_service="$1"
+                ;;
+            "tourguide")
+                # do not modify service, as an empty value will start all containers
+                ;;
+            *)
+                echo "Unknown service: $1"
+                module_help
+                ;;
+        esac
+    fi
+}
+
+function module_cmd () {
+    module_options "$@"
+    docker-compose up -d ${start_service}
+}

--- a/cli/stop
+++ b/cli/stop
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+#  stop
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  stop command for TourGuide CLI.
+#
+
+remove_containers=0
+
+function module_help () {
+    cat <<EOF >&2
+Usage: ${appname} stop [-h | --help] [-r | --remove]
+
+Stops all the services currently running.
+
+Command options:
+
+  -h  --help                 Show this help.
+  -r  --remove               Remove docker containers after stopping them.
+                             Default is NOT to remove the containers.
+
+EOF
+    exit 0
+}
+
+function module_options () {
+    TEMP=`getopt -o hr -l help,remove -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        module_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                module_help
+                ;;
+            "-r" | "--remove")
+                remove_containers=1
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        module_help
+    fi
+}
+
+function module_cmd () {
+    module_options "$@"
+    docker-compose stop
+    if [ $remove_containers -eq 1 ] ; then
+        docker-compose rm -f -v
+    fi
+}


### PR DESCRIPTION
This PR adds the `start` and `stop` commands to the CLI. This PR depends on #127.

These are simple wrappers around docker-compose.
