### PR TITLE
CLI: Add load commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -51,11 +51,19 @@ Get the OAuth credentials for TourGuide, as defined on Keyrock, and configure th
 
 ### load ###
 
+Load sample data for TourGuide-App (restaurants, reservations and reviews).
+
 #### load restaurants ####
+
+Load sample restaurants for TourGuide-App.
 
 #### load reservations ####
 
+Create sample reservations for the restaurants available on TourGuide-App.
+
 #### load reviews ####
+
+Create sample reviews for the restaurants available on TourGuide-App.
 
 ### oauth-token ###
 

--- a/cli/load
+++ b/cli/load
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+#  load
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  load command for TourGuide CLI.
+#
+
+load_command=""
+
+function module_help () {
+    cat <<EOF >&2
+Usage: ${appname} load [-h | --help] <data-type> <options>
+
+Load sample data into TourGuide-App.
+
+Available data options:
+
+  restaurants                Load sample restaurants.
+  reservations               Generate random reservations for the restaurants.
+  reviews                    Generate random reviews for the restaurants.
+
+Command options:
+
+  -h  --help                 Show this help.
+
+Use '${appname} load <data-type> --help' to get help about a specific <data-type> option.
+
+EOF
+    exit 0
+}
+
+function module_options () {
+    if [ $# -lt 1 ]; then
+        module_help
+    else
+        case "$1" in
+            "-h" | "--help" )
+                module_help
+                ;;
+            "restaurants"|"reservations"|"reviews")
+                load_command="$1"
+                shift
+                ;;
+            "-"*)
+                echo "Unknown parameter: $1"
+                module_help
+                ;;
+            *)
+                echo "Unknown command: $1"
+                module_help
+                ;;
+        esac
+    fi
+}
+
+function module_cmd () {
+    module_options "$@"
+    shift
+    if [ -e "${modules_dir}/${command}_${load_command}" ] ; then
+        source "${modules_dir}/${command}_${load_command}"
+        submodule_cmd "$@"
+    fi
+}

--- a/cli/load_reservations
+++ b/cli/load_reservations
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+#  load_reservations
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  load reservations subcommand for TourGuide CLI.
+#
+
+load_reservations_wait=0
+restaurant_name=""
+limit=0
+feeder_params=""
+from_date=""
+to_date=""
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} load reservations [-h | --help] [-w | --wait] [-r <name> | --restaurant <name>]
+                                    [-l <n> | --limit <n>] [-f <date> | --from <date>]
+                                    [-t <date> | --to <date>]
+
+Create reservations for the loaded restaurants.
+
+Command options:
+
+  -h  --help                 Show this help.
+  -w  --wait                 Wait for the tourguide container to be ready.
+                             Default is to exit if tourguide container is not ready.
+  -r  --restaurant <name>    Create a reservation for a single restaurant using its <name>.
+                             Default is to create reservations for all available restaurants.
+  -l  --limit <n>            Limit the number of reservations to load per restaurant to <n>.
+                             Default is 1 reservation per restaurant.
+  -f  --from <date>          Create reservations from <date> on.
+                             Use ISO8601 date format.
+  -t  --to <date>            Create reservations up to <date>.
+                             Use ISO8601 date format.
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hwr:l:f:t: -l help,wait,restaurant:,limit:,from:,to: -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-w" | "--wait")
+                shift
+                load_reservations_wait=1
+                ;;
+            "-r" | "--restaurant")
+                shift
+                restaurant_name=$1
+                ;;
+            "-l" | "--limit")
+                shift
+                limit=$1
+                ;;
+            "-f" | "--from")
+                shift
+                from_date=$1
+                ;;
+            "-t" | "--to")
+                shift
+                to_date=$1
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        submodule_help
+    fi
+
+    [ ${limit} -gt 0 ] && feeder_params="${feeder_params} --numberOfReservations ${limit}"
+    [ ! -z "${restaurant_name}" ] && feeder_params="${feeder_params} --restaurant '${restaurant_name}'"
+    [ ! -z "${from_date}" ] && feeder_params="${feeder_params} --fromDate '${from_date}'"
+    [ ! -z "${to_date}" ] && feeder_params="${feeder_params} --toDate '${to_date}'"
+}
+
+function submodule_cmd () {
+    local _started=0
+    local _tries=0
+    local _container_name="${container_prefix}tourguide"
+
+    submodule_options "$@"
+
+    while [ true ]; do
+        echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
+        if ( docker logs ${_container_name} 2>&1 | grep -qE "service apache2 reload" ) ; then
+            echo "OK."
+            _started=1
+        fi
+
+        if [ ${_started} -eq 0 -a ${load_reservations_wait} -eq 1 ]; then
+            sleep 1
+            _tries=$(( ${_tries} + 1 ))
+            echo "Retrying."
+        else
+            break
+        fi
+    done
+
+    if [ ${_started} -eq 1 ]; then
+        docker exec -i -t ${_container_name} /bin/bash -c "cd tutorials.TourGuide-App/server/feeders; node reservationsgenerator.js ${feeder_params}"
+    else
+        echo "Not ready."
+        echo "Stopping."
+    fi
+}

--- a/cli/load_reservations
+++ b/cli/load_reservations
@@ -88,10 +88,14 @@ function submodule_options () {
         submodule_help
     fi
 
-    [ ${limit} -gt 0 ] && feeder_params="${feeder_params} --numberOfReservations ${limit}"
-    [ ! -z "${restaurant_name}" ] && feeder_params="${feeder_params} --restaurant '${restaurant_name}'"
-    [ ! -z "${from_date}" ] && feeder_params="${feeder_params} --fromDate '${from_date}'"
-    [ ! -z "${to_date}" ] && feeder_params="${feeder_params} --toDate '${to_date}'"
+    [ ${limit} -gt 0 ] &&
+        feeder_params="${feeder_params} --numberOfReservations ${limit}"
+    [ ! -z "${restaurant_name}" ] &&
+        feeder_params="${feeder_params} --restaurant '${restaurant_name}'"
+    [ ! -z "${from_date}" ] &&
+        feeder_params="${feeder_params} --fromDate '${from_date}'"
+    [ ! -z "${to_date}" ] &&
+        feeder_params="${feeder_params} --toDate '${to_date}'"
 }
 
 function submodule_cmd () {
@@ -103,7 +107,8 @@ function submodule_cmd () {
 
     while [ true ]; do
         echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
-        if ( docker logs ${_container_name} 2>&1 | grep -qE "service apache2 reload" ) ; then
+        if ( docker logs ${_container_name} 2>&1 |
+                 grep -qE "service apache2 reload" ) ; then
             echo "OK."
             _started=1
         fi
@@ -118,7 +123,9 @@ function submodule_cmd () {
     done
 
     if [ ${_started} -eq 1 ]; then
-        docker exec -i -t ${_container_name} /bin/bash -c "cd tutorials.TourGuide-App/server/feeders; node reservationsgenerator.js ${feeder_params}"
+        docker exec -i -t ${_container_name} /bin/bash -c \
+               "cd tutorials.TourGuide-App/server/feeders; \
+                node reservationsgenerator.js ${feeder_params}"
     else
         echo "Not ready."
         echo "Stopping."

--- a/cli/load_restaurants
+++ b/cli/load_restaurants
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+#  load_restaurants
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  load restaurants subcommand for TourGuide CLI.
+#
+
+load_restaurants_wait=0
+restaurant_name=""
+limit=0
+feeder_params=""
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} load restaurants [-h | --help] [-w | --wait] [-r <name> | --restaurant <name>]
+                                   [-l <n> | --limit <n>]
+
+Load sample restaurants for use with TourGuide-App.
+
+Command options:
+
+  -h  --help                 Show this help.
+  -w  --wait                 Wait for the tourguide container to be ready.
+                             Default is to exit if tourguide container is not ready.
+  -r  --restaurant <name>    Load a single restaurant using its <name>.
+  -l  --limit <n>            Limit the number of restaurants to load to <n>.
+                             Using --restaurant limits <n> to 1.
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hwr:l: -l help,wait,restaurant:,limit: -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-w" | "--wait")
+                shift
+                load_restaurants_wait=1
+                ;;
+            "-r" | "--restaurant")
+                shift
+                restaurant_name=$1
+                ;;
+            "-l" | "--limit")
+                shift
+                limit=$1
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        submodule_help
+    fi
+
+    [ ${limit} -gt 0 ] && feeder_params="--numberOfRestaurants ${limit}"
+    [ ! -z "${restaurant_name}" ] && feeder_params="--restaurant '${restaurant_name}'"
+}
+
+function submodule_cmd () {
+    local _started=0
+    local _tries=0
+    local _container_name="${container_prefix}tourguide"
+
+    submodule_options "$@"
+
+    while [ true ]; do
+        echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
+        if ( docker logs ${_container_name} 2>&1 | grep -qE "service apache2 reload" ) ; then
+            echo "OK."
+            _started=1
+        fi
+
+        if [ ${_started} -eq 0 -a ${load_restaurants_wait} -eq 1 ]; then
+            sleep 1
+            _tries=$(( ${_tries} + 1 ))
+            echo "Retrying."
+        else
+            break
+        fi
+    done
+
+    if [ ${_started} -eq 1 ]; then
+        docker exec -i -t ${_container_name} /bin/bash -c "cd tutorials.TourGuide-App/server/feeders; node restaurantfeeder.js ${feeder_params}"
+    else
+        echo "Not ready."
+        echo "Stopping."
+    fi
+}

--- a/cli/load_restaurants
+++ b/cli/load_restaurants
@@ -27,7 +27,7 @@ Command options:
                              Default is to exit if tourguide container is not ready.
   -r  --restaurant <name>    Load a single restaurant using its <name>.
   -l  --limit <n>            Limit the number of restaurants to load to <n>.
-                             Using --restaurant limits <n> to 1.
+                             This option is ignored when using --restaurant option.
 
 EOF
     exit 0

--- a/cli/load_restaurants
+++ b/cli/load_restaurants
@@ -72,8 +72,10 @@ function submodule_options () {
         submodule_help
     fi
 
-    [ ${limit} -gt 0 ] && feeder_params="--numberOfRestaurants ${limit}"
-    [ ! -z "${restaurant_name}" ] && feeder_params="--restaurant '${restaurant_name}'"
+    [ ${limit} -gt 0 ] &&
+        feeder_params="--numberOfRestaurants ${limit}"
+    [ ! -z "${restaurant_name}" ] &&
+        feeder_params="--restaurant '${restaurant_name}'"
 }
 
 function submodule_cmd () {
@@ -85,7 +87,8 @@ function submodule_cmd () {
 
     while [ true ]; do
         echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
-        if ( docker logs ${_container_name} 2>&1 | grep -qE "service apache2 reload" ) ; then
+        if ( docker logs ${_container_name} 2>&1 |
+                 grep -qE "service apache2 reload" ) ; then
             echo "OK."
             _started=1
         fi
@@ -100,7 +103,9 @@ function submodule_cmd () {
     done
 
     if [ ${_started} -eq 1 ]; then
-        docker exec -i -t ${_container_name} /bin/bash -c "cd tutorials.TourGuide-App/server/feeders; node restaurantfeeder.js ${feeder_params}"
+        docker exec -i -t ${_container_name} /bin/bash -c \
+               "cd tutorials.TourGuide-App/server/feeders; \
+               node restaurantfeeder.js ${feeder_params}"
     else
         echo "Not ready."
         echo "Stopping."

--- a/cli/load_reviews
+++ b/cli/load_reviews
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+#  load_reviews
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  load reviews subcommand for TourGuide CLI.
+#
+
+load_reviews_wait=0
+restaurant_name=""
+limit=0
+feeder_params=""
+from_date=""
+to_date=""
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} load reviews [-h | --help] [-w | --wait] [-r <name> | --restaurant <name>]
+                                    [-l <n> | --limit <n>] [-o <name> | --organization <name>]
+
+Create reviews for the loaded restaurants.
+
+Command options:
+
+  -h  --help                 Show this help.
+  -w  --wait                 Wait for the tourguide container to be ready.
+                             Default is to exit if tourguide container is not ready.
+  -r  --restaurant <name>    Create a review for a single restaurant using its <name>.
+                             Default is to create reviews for all available restaurants.
+  -l  --limit <n>            Limit the number of reviews to load per restaurant to <n>.
+                             Default is 1 review per restaurant.
+  -o  --organization <name>  Create reviews for all the restaurants of a given organization.
+                             Default is to create reviews for all available restaurants.
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hwr:l:o: -l help,wait,restaurant:,limit:,organization: -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-w" | "--wait")
+                shift
+                load_reviews_wait=1
+                ;;
+            "-r" | "--restaurant")
+                shift
+                restaurant_name=$1
+                ;;
+            "-l" | "--limit")
+                shift
+                limit=$1
+                ;;
+            "-o" | "--organization")
+                shift
+                organization_name=$1
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        submodule_help
+    fi
+
+    [ ${limit} -gt 0 ] && feeder_params="${feeder_params} --numberOfReviews ${limit}"
+    [ ! -z "${restaurant_name}" ] && feeder_params="${feeder_params} --restaurant '${restaurant_name}'"
+    [ ! -z "${organization_name}" ] && feeder_params="${feeder_params} --organization '${organization_name}'"
+}
+
+function submodule_cmd () {
+    local _started=0
+    local _tries=0
+    local _container_name="${container_prefix}tourguide"
+
+    submodule_options "$@"
+
+    while [ true ]; do
+        echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
+        if ( docker logs ${_container_name} 2>&1 | grep -qE "service apache2 reload" ) ; then
+            echo "OK."
+            _started=1
+        fi
+
+        if [ ${_started} -eq 0 -a ${load_reviews_wait} -eq 1 ]; then
+            sleep 1
+            _tries=$(( ${_tries} + 1 ))
+            echo "Retrying."
+        else
+            break
+        fi
+    done
+
+    if [ ${_started} -eq 1 ]; then
+        docker exec -i -t ${_container_name} /bin/bash -c "cd tutorials.TourGuide-App/server/feeders; node reviewsgenerator.js ${feeder_params}"
+    else
+        echo "Not ready."
+        echo "Stopping."
+    fi
+}

--- a/cli/load_reviews
+++ b/cli/load_reviews
@@ -81,9 +81,12 @@ function submodule_options () {
         submodule_help
     fi
 
-    [ ${limit} -gt 0 ] && feeder_params="${feeder_params} --numberOfReviews ${limit}"
-    [ ! -z "${restaurant_name}" ] && feeder_params="${feeder_params} --restaurant '${restaurant_name}'"
-    [ ! -z "${organization_name}" ] && feeder_params="${feeder_params} --organization '${organization_name}'"
+    [ ${limit} -gt 0 ] &&
+        feeder_params="${feeder_params} --numberOfReviews ${limit}"
+    [ ! -z "${restaurant_name}" ] &&
+        feeder_params="${feeder_params} --restaurant '${restaurant_name}'"
+    [ ! -z "${organization_name}" ] &&
+        feeder_params="${feeder_params} --organization '${organization_name}'"
 }
 
 function submodule_cmd () {
@@ -95,7 +98,8 @@ function submodule_cmd () {
 
     while [ true ]; do
         echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
-        if ( docker logs ${_container_name} 2>&1 | grep -qE "service apache2 reload" ) ; then
+        if ( docker logs ${_container_name} 2>&1 |
+                 grep -qE "service apache2 reload" ) ; then
             echo "OK."
             _started=1
         fi
@@ -110,7 +114,9 @@ function submodule_cmd () {
     done
 
     if [ ${_started} -eq 1 ]; then
-        docker exec -i -t ${_container_name} /bin/bash -c "cd tutorials.TourGuide-App/server/feeders; node reviewsgenerator.js ${feeder_params}"
+        docker exec -i -t ${_container_name} /bin/bash -c \
+               "cd tutorials.TourGuide-App/server/feeders; \
+               node reviewsgenerator.js ${feeder_params}"
     else
         echo "Not ready."
         echo "Stopping."


### PR DESCRIPTION
This PR adds the `load`, `load restaurants`, `load reservations` and `load reviews` commands to the CLI. This PR depends on both #127 and #122.

These commands allows the user to load sample data for use in TourGuide-App.
