### PR TITLE
CLI: Add configure commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -31,11 +31,23 @@ Check if some required commands (both for running the containers and the scripts
 
 ### configure ###
 
+Allows the user to apply some configuration changes to some services.  This command has the following subcommands:
+
 #### configure cygnus ####
+
+Allows the user to configure the MySQL username and password for Cygnus.
+
+#### configure hosts ####
+
+Modify the hosts file to add entries for the running docker containers.
 
 #### configure keyrock ####
 
+Provision the TourGuide-App users, roles and permissions on Keyrock, then sync with Authzforce.
+
 #### configure oauth ####
+
+Get the OAuth credentials for TourGuide, as defined on Keyrock, and configure them on TourGuide-App container.
 
 ### load ###
 

--- a/cli/configure
+++ b/cli/configure
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+#  configure
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  configure command for TourGuide CLI.
+#
+
+configure_service=""
+
+function module_help () {
+    cat <<EOF >&2
+Usage: ${appname} configure [-h | --help] <service> <options>
+
+Apply configuration changes for <service>.
+
+Available services:
+
+  * cygnus        Configure Cygnus MySQL username and password.
+  * keyrock       Provision Tour Guide users, roles and permissions on Keyrock and sync with Authzforce
+  * oauth         Configure OAuth credentials on Tour Guide container.
+  * hosts         Update hosts file to add the containers IPs and hostnames.
+
+Command options:
+
+  -h  --help                 Show this help.
+
+Use '${appname} configure <service> --help' to get help about
+configuration options for a specific <service>.
+
+EOF
+    exit 0
+}
+
+function module_options () {
+    if [ $# -lt 1 ]; then
+        module_help
+    else
+        case "$1" in
+            "-h" | "--help" )
+                module_help
+                ;;
+            "cygnus"|"keyrock"|"oauth"|"hosts")
+                configure_service="$1"
+                shift
+                ;;
+            "-"*)
+                echo "Unknown parameter: $1"
+                module_help
+                ;;
+            *)
+                echo "Unknown service: $1"
+                module_help
+                ;;
+        esac
+    fi
+}
+
+function module_cmd () {
+    module_options "$@"
+    shift
+    if [ -e "${modules_dir}/${command}_${configure_service}" ] ; then
+        source "${modules_dir}/${command}_${configure_service}"
+        submodule_cmd "$@"
+    fi
+}

--- a/cli/configure_cygnus
+++ b/cli/configure_cygnus
@@ -74,19 +74,27 @@ function submodule_cmd () {
 
     local sum=$( md5sum "${compose}" )
     # configure cygnus container
+    local cyg_user="CYGNUS_MYSQL_USER=${cygnus_mysql_user}"
+    local cyg_pass="CYGNUS_MYSQL_PASS=${cygnus_mysql_password}"
     sed -i "${compose}" \
-        -e "/^cygnus:/,/^$/ s/CYGNUS_MYSQL_USER=.*$/CYGNUS_MYSQL_USER=${cygnus_mysql_user}/" \
-        -e "/^cygnus:/,/^$/ s/CYGNUS_MYSQL_PASS=.*$/CYGNUS_MYSQL_PASS=${cygnus_mysql_password}/"
+        -e "/^cygnus:/,/^$/ s/CYGNUS_MYSQL_USER=.*$/${cyg_user}/" \
+        -e "/^cygnus:/,/^$/ s/CYGNUS_MYSQL_PASS=.*$/${cyg_pass}/"
 
     # configure mysql container
     if [ "${cygnus_mysql_user}" = "root" ] ; then
+        local my_pass="        - MYSQL_ROOT_PASSWORD=${cygnus_mysql_password}"
         sed -i "${compose}" \
             -e "/^mysql:/,/^$/ {/environment:/,/^$/ { /- /d}}" \
-            -e "/^mysql:/,/^$/ {/environment:/ s/environment:.*$/environment:\n        - MYSQL_ROOT_PASSWORD=${cygnus_mysql_password}/}"
+            -e "/^mysql:/,/^$/ \
+                {/environment:/ s/environment:.*$/environment:\n${my_pass}/}"
     else
+        local my_user="        - MYSQL_USER=${cygnus_mysql_user}"
+        local my_pass="        - MYSQL_PASSWORD=${cygnus_mysql_password}"
+        local my_db="        - MYSQL_DATABASE=${fiware_service}"
+        local env_exp="environment:\\n${my_user}\\n${my_pass}\\n${my_db}"
         sed -i "${compose}" \
             -e "/^mysql:/,/^$/ {/environment:/,/^$/ { /- /d}}" \
-            -e "/^mysql:/,/^$/ {/environment:/ s/environment:.*$/environment:\n        - MYSQL_USER=${cygnus_mysql_user}\n        - MYSQL_PASSWORD=${cygnus_mysql_password}\n        - MYSQL_DATABASE=${fiware_service}/}"
+            -e "/^mysql:/,/^$/ {/environment:/ s/environment:.*$/${env_exp}/}"
     fi
 
     local mod=$( md5sum "${compose}" )

--- a/cli/configure_cygnus
+++ b/cli/configure_cygnus
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+#  configure_cygnus
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  configure cygnus subcommand for TourGuide CLI.
+#
+
+cygnus_mysql_user='root'
+cygnus_mysql_password='mysql'
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} configure cygnus [-h | --help] [-u <username> | --mysql-user <username>]
+                                   [-p <password> | --mysql-password <password>]
+
+Apply configuration changes for cygnus.
+
+Command options:
+
+  -h  --help                         Show this help.
+  -u  --mysql-user <username>        Set the MySQL database user to use.
+                                     Default value is 'root'.
+  -p  --mysql-password <password>    Set the MySQL database password to use.
+                                     Default value is 'mysql'.
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    if [ $# -lt 1 ]; then
+        submodule_help
+    else
+        TEMP=`getopt -o hu:p: -l help,mysql-user:,mysql-password: -- "$@"`
+
+        if test "$?" -ne 0 ; then
+            submodule_help
+        fi
+
+        eval set -- "$TEMP"
+
+        while true ; do
+            case "$1" in
+                "-h" | "--help" )
+                    submodule_help
+                    ;;
+                "-u" | "--mysql-user" )
+                    shift
+                    cygnus_mysql_user=$1
+                    ;;
+                "-p" | "--mysql-password" )
+                    shift
+                    cygnus_mysql_password=$1
+                    ;;
+                --|*)
+                    break;
+                    ;;
+            esac
+            shift
+        done
+        shift
+
+        if [ $# -gt 0 ]; then
+            echo "Unknown parameters: $@"
+            submodule_help
+        fi
+    fi
+}
+
+function submodule_cmd () {
+    submodule_options "$@"
+
+    local sum=$( md5sum "${compose}" )
+    # configure cygnus container
+    sed -i "${compose}" \
+        -e "/^cygnus:/,/^$/ s/CYGNUS_MYSQL_USER=.*$/CYGNUS_MYSQL_USER=${cygnus_mysql_user}/" \
+        -e "/^cygnus:/,/^$/ s/CYGNUS_MYSQL_PASS=.*$/CYGNUS_MYSQL_PASS=${cygnus_mysql_password}/"
+
+    # configure mysql container
+    if [ "${cygnus_mysql_user}" = "root" ] ; then
+        sed -i "${compose}" \
+            -e "/^mysql:/,/^$/ {/environment:/,/^$/ { /- /d}}" \
+            -e "/^mysql:/,/^$/ {/environment:/ s/environment:.*$/environment:\n        - MYSQL_ROOT_PASSWORD=${cygnus_mysql_password}/}"
+    else
+        sed -i "${compose}" \
+            -e "/^mysql:/,/^$/ {/environment:/,/^$/ { /- /d}}" \
+            -e "/^mysql:/,/^$/ {/environment:/ s/environment:.*$/environment:\n        - MYSQL_USER=${cygnus_mysql_user}\n        - MYSQL_PASSWORD=${cygnus_mysql_password}\n        - MYSQL_DATABASE=${fiware_service}/}"
+    fi
+
+    local mod=$( md5sum "${compose}" )
+    if [ "${mod}" != "${sum}" ]; then
+        echo "Updated ${compose}." >&2
+    else
+        echo "No modifications applied to ${compose}." >&2
+    fi
+}

--- a/cli/configure_hosts
+++ b/cli/configure_hosts
@@ -44,7 +44,8 @@ function check_permissions () {
         fi
     else
         if [ ! -w "${hosts_file}" ] ; then
-            echo "Hosts file '${hosts_file}' does not have write permission for user ${user}."
+            echo -n "Hosts file '${hosts_file}' "
+            echo "does not have write permission for user ${user}."
             exit 1
         fi
     fi
@@ -188,14 +189,18 @@ function submodule_cmd () {
     fi
 
     # get list of running containers
-    containers_running=($( docker inspect --format "{{if .State.Running}}{{.Id}}{{end}}" "${containers_list[@]}" ))
+    containers_running=($( docker inspect --format \
+                                  "{{if .State.Running}}{{.Id}}{{end}}" \
+                                  "${containers_list[@]}" ))
     if [ -z "${containers_running}" ] ; then
         echo "There's no running containers."
         echo "Hosts file will NOT be modified."
         exit 0
     else
         # get the names of the running containers
-        container_names=( $( docker inspect --format '{{.Name}}' "${containers_running[@]}" ) )
+        container_names=( $( docker inspect --format \
+                                    "{{.Name}}" \
+                                    "${containers_running[@]}" ) )
         container_names=( "${container_names[@]#/}" )
 
         # get the list of links
@@ -204,7 +209,9 @@ function submodule_cmd () {
         # dump hosts info
         docker_hosts=$(
             for name in "${container_names[@]}" ; do
-                local ip=$( docker inspect -f "{{ .NetworkSettings.IPAddress }}" "${name}" )
+                local ip=$( docker inspect --format \
+                                   "{{ .NetworkSettings.IPAddress }}" \
+                                   "${name}" )
                 local aliases=$( get_container_aliases "${name}" )
                 echo "${ip}    ${name} ${aliases}" | sed -e 's/[ ]*$//g'
             done )
@@ -217,7 +224,8 @@ function submodule_cmd () {
                 sed -i "${hosts_file}" \
                     -e "/^${begin_tag}\$/,/^${end_tag}\$/{d}"
             fi
-            echo -e "${begin_tag}\n${docker_hosts}\n${end_tag}" >> "${hosts_file}"
+            echo -e "${begin_tag}\n${docker_hosts}\n${end_tag}" \
+                 >> "${hosts_file}"
         else
             echo -e "${begin_tag}\n${docker_hosts}\n${end_tag}"
         fi

--- a/cli/configure_hosts
+++ b/cli/configure_hosts
@@ -1,0 +1,225 @@
+#!/bin/bash
+#
+#  configure_hosts
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  configure hosts subcommand for TourGuide CLI.
+#
+
+supported_os=1
+requires_root=0
+default_hosts_file=""
+begin_tag="### BEGIN Docker container IPs ###"
+end_tag="### END Docker container IPs ###"
+modify_hosts=0
+
+function check_os () {
+    local os=$( uname )
+    case "${os}" in
+        "Darwin")
+            echo "Operating System: Mac OS X"
+            default_hosts_file="/private/etc/hosts"
+            ;;
+        "Linux")
+            echo "Operating System: Linux"
+            default_hosts_file="/etc/hosts"
+            ;;
+        *)
+            echo "Operating System: Unsupported"
+            supported_os=0
+            exit 1
+            ;;
+    esac
+}
+
+function check_permissions () {
+    local user=$( whoami )
+    if [ ${requires_root} -eq 1 ] ; then
+        if [ "${user}" != "root" ] ; then
+            echo "Only root is allowed to modify ${hosts_file}"
+            echo "Run the script as root or use an alternate method like sudo"
+            exit 1
+        fi
+    else
+        if [ ! -w "${hosts_file}" ] ; then
+            echo "Hosts file '${hosts_file}' does not have write permission for user ${user}."
+            exit 1
+        fi
+    fi
+}
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} configure hosts [-h | --help]
+
+Modify the hosts file to add entries for the running docker containers.
+
+Command options:
+
+  -h  --help                 Show this help.
+
+  -m  --modify-hosts         Modify the system /etc/hosts file (requires root permission)
+                             Default is to show the list of entries that would have been added.
+  -f  --hosts-file <file>    Use <file> as the hosts file to modify.
+                             Default is /etc/hosts for Linux and /private/etc/hosts for OS X.
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hmf: -l help,modify-hosts,hosts-file: -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-m" | "--modify-hosts")
+                modify_hosts=1
+                ;;
+            "-f" | "--hosts-file")
+                shift
+                hosts_file="$1"
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        module_help
+    fi
+
+    check_os
+    if [ -z "${hosts_file}" ] ; then
+        echo "No hosts file specified."
+        echo "Using OS default: ${default_hosts_file}"
+        hosts_file="${default_hosts_file}"
+        requires_root=1
+    fi
+}
+
+function backup_hosts_file () {
+    local file="$1"
+    local backup_file="${file}.tourguide.$( date +%Y%m%d.%H%M%S )"
+
+    echo "Backing up '${file}' to '${backup_file}'"
+    cp "${file}" "${backup_file}"
+    if [ $? -ne 0 ] ; then
+        echo "Failed to create backup file '${backup_file}'."
+        echo "Cannot continue without backup file."
+        exit 1
+    fi
+}
+
+function get_container_links () {
+    local container_names=("$@")
+    local links=$(
+        docker inspect -f "{{ .HostConfig.Links }}" "${container_names[@]}" |
+            grep -v -F "<no value>" |
+            tr ' ' '\n' |
+            sed -e 's/^\[//g' \
+                -e 's/\]$//g' \
+                -e 's|:/[^/]\+/|:|g' \
+                -e 's|/||g' \
+                -e '/^\([^:]\+\):\1/ d' |
+            sort -u )
+    [ -n "${links}" ] && echo "${links}"
+}
+
+function get_extra_aliases () {
+    local host="$1"
+    local aliases=$(
+        cat "${hosts_file}" |
+            grep "\(^\|[ ]\)${host}\([ ]\|$\)" |
+            sed -e 's/^[^ \t]\+[ \t]\+//g' |
+            tr '\n' ' ' |
+            sed -e "s/\(^\|[ ]\)${host}\([ ]\|$\)/ /g" \
+                -e 's/^[ ]*//g' \
+                -e 's/[ ]*$//g' \
+                -e 's/[ ]\+/ /g' |
+            tr ' ' '\n' |
+            sort -u |
+            sed -e 's/^[ ]*$//g' )
+    [ -n "${aliases}" ] && echo "${aliases}"
+}
+
+function get_container_aliases () {
+    local name="$1"
+    local aliases=""
+    local links=$( echo "${container_links}" |
+                         grep "^${name}:" |
+                         cut -d ':' -f 2- |
+                         tr '\n' ' ' )
+    local extra=$( get_extra_aliases "${name}" )
+    local hostname=$( docker inspect -f "{{.Config.Hostname}}" "${name}" )
+    if [ -n "$links" -o -n "$extra" -o -n "$hostname" ]; then
+        aliases=$( echo $links $extra $hostname |
+                         tr ' ' '\n' |
+                         sort -u |
+                         sed -e 's/^[ ]*$//g' |
+                         tr '\n' ' ' )
+    fi
+    [ -n "${aliases}" ] && echo "${aliases}"
+}
+
+function submodule_cmd () {
+    submodule_options "$@"
+
+    # get list of all containers
+    containers_list=($( docker ps -a -q --no-trunc ))
+    if [ "${#containers_list[@]}" -eq 0 ] ; then
+        echo "No containers found."
+        echo "Hosts file will NOT be modified."
+        exit 0
+    fi
+
+    # get list of running containers
+    containers_running=($( docker inspect --format "{{if .State.Running}}{{.Id}}{{end}}" "${containers_list[@]}" ))
+    if [ -z "${containers_running}" ] ; then
+        echo "There's no running containers."
+        echo "Hosts file will NOT be modified."
+        exit 0
+    else
+        # get the names of the running containers
+        container_names=( $( docker inspect --format '{{.Name}}' "${containers_running[@]}" ) )
+        container_names=( "${container_names[@]#/}" )
+
+        # get the list of links
+        container_links=$( get_container_links "${container_names[@]}" )
+
+        # dump hosts info
+        docker_hosts=$(
+            for name in "${container_names[@]}" ; do
+                local ip=$( docker inspect -f "{{ .NetworkSettings.IPAddress }}" "${name}" )
+                local aliases=$( get_container_aliases "${name}" )
+                echo "${ip}    ${name} ${aliases}" | sed -e 's/[ ]*$//g'
+            done )
+
+        if [ ${modify_hosts} -eq 1 ]; then
+            check_permissions
+            backup_hosts_file "${hosts_file}"
+            echo "Modifying ${hosts_file}"
+            if grep -q "^${begin_tag}" "${hosts_file}" ; then
+                sed -i "${hosts_file}" \
+                    -e "/^${begin_tag}\$/,/^${end_tag}\$/{d}"
+            fi
+            echo -e "${begin_tag}\n${docker_hosts}\n${end_tag}" >> "${hosts_file}"
+        else
+            echo -e "${begin_tag}\n${docker_hosts}\n${end_tag}"
+        fi
+    fi
+}

--- a/cli/configure_keyrock
+++ b/cli/configure_keyrock
@@ -86,7 +86,8 @@ function check_host_port () {
     echo "Testing if port '${_port}' is open at host '${_host}'."
 
     while [ ${_tries} -lt ${_max_tries} -a ${_is_open} -eq 0 ] ; do
-        echo -n "Checking connection to '${_host}:${_port}' [try $(( ${_tries} + 1 ))/${_max_tries}] ... "
+        echo -n "Checking connection to '${_host}:${_port}' "
+        echo -n "[try $(( ${_tries} + 1 ))/${_max_tries}] ... "
         if ${NC} -z -w ${_timeout} ${_host} ${_port} ; then
             echo "OK."
             _is_open=1
@@ -102,7 +103,8 @@ function check_host_port () {
     done
 
     if [ ${_is_open} -eq 0 ] ; then
-        echo "Failed to connect to port '${_port}' on host '${_host}' after ${_tries} tries."
+        echo -n "Failed to connect to port '${_port}' on host '${_host}'"
+        echo " after ${_tries} tries."
         echo "Port is closed or host is unreachable."
         exit 1
     else
@@ -121,9 +123,12 @@ function submodule_cmd () {
 
     # copy the needed files to the keyrock container
     echo "Copying scripts to keyrock container."
-    docker cp ${keyrock_scripts_path}/tourguide-provision.py ${_container_name}:/opt/
-    docker cp ${keyrock_scripts_path}/params-config.py ${_container_name}:/opt/
-    docker cp ${keyrock_scripts_path}/access_control_xacml.py ${_container_name}:/horizon/
+    docker cp ${keyrock_scripts_path}/tourguide-provision.py \
+           ${_container_name}:/opt/
+    docker cp ${keyrock_scripts_path}/params-config.py \
+           ${_container_name}:/opt/
+    docker cp ${keyrock_scripts_path}/access_control_xacml.py \
+           ${_container_name}:/horizon/
 
     # provision tourguide users, roles and permissions
     echo "Provisioning TourGuide users, roles and permissions."
@@ -131,15 +136,22 @@ function submodule_cmd () {
            'cd /keystone ; \
             source .venv/bin/activate ; \
             (sleep 5 ; echo idm) | bin/keystone-manage -v db_sync --populate ; \
-            [ ! -e /opt/.provision-done ] && python /opt/tourguide-provision.py && touch /opt/.provision-done'
+            [ ! -e /opt/.provision-done ] && \
+            python /opt/tourguide-provision.py && \
+            touch /opt/.provision-done'
 
     # configure access and sync with authzforce
     echo "Syncing with authzforce."
+    local ac_url="ACCESS_CONTROL_URL = '${keyrock_ac_url}'"
+    local ac_key="ACCESS_CONTROL_MAGIC_KEY = '${keyrock_ac_magic_key}'"
     docker exec -i ${_container_name} /bin/bash -c \
            "sed -i /horizon/openstack_dashboard/local/local_settings.py \
-            -e \"s|^ACCESS_CONTROL_URL = None|ACCESS_CONTROL_URL = '${keyrock_ac_url}'|\" \
-            -e \"s|^ACCESS_CONTROL_MAGIC_KEY = None|ACCESS_CONTROL_MAGIC_KEY = '${keyrock_ac_magic_key}'|\" ; \
-            python /opt/params-config.py --name 'TourGuide' --file /opt/config.json --database keystone.db ; \
+            -e \"s|^ACCESS_CONTROL_URL = None|${ac_url}|\" \
+            -e \"s|^ACCESS_CONTROL_MAGIC_KEY = None|${ac_key}|\" ; \
+            python /opt/params-config.py \
+                   --name 'TourGuide' \
+                   --file /opt/config.json \
+                   --database keystone.db ; \
             cd /horizon ; \
             source .venv/bin/activate ; \
             python access_control_xacml.py"

--- a/cli/configure_keyrock
+++ b/cli/configure_keyrock
@@ -1,0 +1,146 @@
+#!/bin/bash
+#
+#  configure_keyrock
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  configure keyrock subcommand for TourGuide CLI.
+#
+
+keyrock_scripts_path="$( dirname $0 )/docker/keyrock"
+keyrock_ac_url="http://authzforce:8080"
+keyrock_ac_magic_key="daf26216c5434a0a80f392ed9165b3b4"
+keyrock_wait=1
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} configure keyrock [-h | --help] [-w | --wait]
+
+Provision the necessary users, roles and permissions for the Tour
+Guide application on Keyrock and then sync with Authzforce.
+
+Command options:
+
+  -h  --help                 Show this help.
+  -w  --wait                 Wait for the keyrock container to be ready.
+                             Default is to exit if keyrock container is not ready.
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hw -l help,wait -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-w" | "--wait")
+                shift
+                keyrock_wait=10000
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        module_help
+    fi
+}
+
+function check_host_port () {
+    local _timeout=10
+    local _tries=0
+    local _is_open=0
+
+    if [ $# -lt 2 ] ; then
+        echo "check_host_port: missing parameters."
+        echo "Usage: check_host_port <host> <port> [max-tries]"
+        exit 1
+    fi
+
+    local _host=$1
+    local _port=$2
+    local _max_tries=${3:-${DEFAULT_MAX_TRIES}}
+    local NC=$( which nc )
+
+    if [ ! -e "${NC}" ] ; then
+        echo "Unable to find 'nc' command."
+        exit 1
+    fi
+
+    echo "Testing if port '${_port}' is open at host '${_host}'."
+
+    while [ ${_tries} -lt ${_max_tries} -a ${_is_open} -eq 0 ] ; do
+        echo -n "Checking connection to '${_host}:${_port}' [try $(( ${_tries} + 1 ))/${_max_tries}] ... "
+        if ${NC} -z -w ${_timeout} ${_host} ${_port} ; then
+            echo "OK."
+            _is_open=1
+        else
+            sleep 1
+            _tries=$(( ${_tries} + 1 ))
+            if [ ${_tries} -lt ${_max_tries} ] ; then
+                echo "Retrying."
+            else
+                echo "Failed."
+            fi
+        fi
+    done
+
+    if [ ${_is_open} -eq 0 ] ; then
+        echo "Failed to connect to port '${_port}' on host '${_host}' after ${_tries} tries."
+        echo "Port is closed or host is unreachable."
+        exit 1
+    else
+        echo "Port '${_port}' at host '${_host}' is open."
+    fi
+}
+
+function submodule_cmd () {
+    local _container_name="${container_prefix}keyrock"
+
+    submodule_options "$@"
+
+    # To check for keyrock, we can check if port 5000 on localhost is
+    # listening, as that port will be mapped to the host.
+    check_host_port localhost 5000 ${keyrock_wait}
+
+    # copy the needed files to the keyrock container
+    echo "Copying scripts to keyrock container."
+    docker cp ${keyrock_scripts_path}/tourguide-provision.py ${_container_name}:/opt/
+    docker cp ${keyrock_scripts_path}/params-config.py ${_container_name}:/opt/
+    docker cp ${keyrock_scripts_path}/access_control_xacml.py ${_container_name}:/horizon/
+
+    # provision tourguide users, roles and permissions
+    echo "Provisioning TourGuide users, roles and permissions."
+    docker exec -i ${_container_name} /bin/bash -c \
+           'cd /keystone ; \
+            source .venv/bin/activate ; \
+            (sleep 5 ; echo idm) | bin/keystone-manage -v db_sync --populate ; \
+            [ ! -e /opt/.provision-done ] && python /opt/tourguide-provision.py && touch /opt/.provision-done'
+
+    # configure access and sync with authzforce
+    echo "Syncing with authzforce."
+    docker exec -i ${_container_name} /bin/bash -c \
+           "sed -i /horizon/openstack_dashboard/local/local_settings.py \
+            -e \"s|^ACCESS_CONTROL_URL = None|ACCESS_CONTROL_URL = '${keyrock_ac_url}'|\" \
+            -e \"s|^ACCESS_CONTROL_MAGIC_KEY = None|ACCESS_CONTROL_MAGIC_KEY = '${keyrock_ac_magic_key}'|\" ; \
+            python /opt/params-config.py --name 'TourGuide' --file /opt/config.json --database keystone.db ; \
+            cd /horizon ; \
+            source .venv/bin/activate ; \
+            python access_control_xacml.py"
+}

--- a/cli/configure_oauth
+++ b/cli/configure_oauth
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+#  configure_oauth
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  configure oauth subcommand for TourGuide CLI.
+#
+
+keyrock_wait=1
+tourguide_wait=0
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} configure oauth [-h | --help] [-w | --wait]
+
+Get the Oauth credentials from Keyrock and add them to the Tour Guide configuration.
+
+Command options:
+
+  -h  --help                 Show this help.
+  -w  --wait                 Wait for the keyrock and tourguide containers to be ready.
+                             Default is to exit if any of the containers is not ready.
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hw -l help,wait -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-w" | "--wait")
+                shift
+                keyrock_wait=10000
+                tourguide_wait=1
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        module_help
+    fi
+}
+
+function check_host_port () {
+    local _timeout=10
+    local _tries=0
+    local _is_open=0
+
+    if [ $# -lt 2 ] ; then
+        echo "check_host_port: missing parameters."
+        echo "Usage: check_host_port <host> <port> [max-tries]"
+        exit 1
+    fi
+
+    local _host=$1
+    local _port=$2
+    local _max_tries=${3:-${DEFAULT_MAX_TRIES}}
+    local NC=$( which nc )
+
+    if [ ! -e "${NC}" ] ; then
+        echo "Unable to find 'nc' command."
+        exit 1
+    fi
+
+    echo "Testing if port '${_port}' is open at host '${_host}'."
+
+    while [ ${_tries} -lt ${_max_tries} -a ${_is_open} -eq 0 ] ; do
+        echo -n "Checking connection to '${_host}:${_port}' [try $(( ${_tries} + 1 ))/${_max_tries}] ... "
+        if ${NC} -z -w ${_timeout} ${_host} ${_port} ; then
+            echo "OK."
+            _is_open=1
+        else
+            sleep 1
+            _tries=$(( ${_tries} + 1 ))
+            if [ ${_tries} -lt ${_max_tries} ] ; then
+                echo "Retrying."
+            else
+                echo "Failed."
+            fi
+        fi
+    done
+
+    if [ ${_is_open} -eq 0 ] ; then
+        echo "Failed to connect to port '${_port}' on host '${_host}' after ${_tries} tries."
+        echo "Port is closed or host is unreachable."
+        exit 1
+    else
+        echo "Port '${_port}' at host '${_host}' is open."
+    fi
+}
+
+function submodule_cmd () {
+    local _started=0
+    local _tries=0
+    local _keyrock_container="${container_prefix}keyrock"
+    local _tourguide_container="${container_prefix}tourguide"
+
+    check_host_port localhost 5000 ${keyrock_wait}
+
+    while [ true ]; do
+        echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
+        if ( docker logs ${_tourguide_container} 2>&1 | grep -qE "service apache2 reload" ) ; then
+            echo "OK."
+            _started=1
+        fi
+
+        if [ ${_started} -eq 0 -a ${tourguide_wait} -ne 0 ]; then
+            sleep 1
+            _tries=$(( ${_tries} + 1 ))
+            echo "Retrying."
+        else
+            break
+        fi
+    done
+
+    if [ ${_started} -eq 1 ]; then
+        # get the OAuth credentials for the app
+        CLIENT_ID=$( echo $( docker exec -i ${_keyrock_container} /bin/bash -c 'cat /opt/config.json' ) | grep -Po '(?<="id": ")[^"]*' )
+        CLIENT_SECRET=$( echo $( docker exec -i ${_keyrock_container} /bin/bash -c 'cat /opt/config.json' ) | grep -Po '(?<="secret": ")[^"]*' )
+        docker exec -i ${_tourguide_container} /bin/bash -c \
+               "sed -i \${CC_APP_SERVER_PATH}/config.js \
+                -e \"s|config.clientId = 'CLIENT_ID'|config.clientId = '${CLIENT_ID}'|g\" \
+                -e \"s|config.clientSecret = 'CLIENT_SECRET'|config.clientSecret = '${CLIENT_SECRET}'|g\" ; \
+                service apache2 reload"
+    else
+        echo "Not ready."
+        echo "Stopping."
+    fi
+}

--- a/cli/configure_oauth
+++ b/cli/configure_oauth
@@ -114,6 +114,8 @@ function submodule_cmd () {
     local _keyrock_container="${container_prefix}keyrock"
     local _tourguide_container="${container_prefix}tourguide"
 
+    submodule_options "$@"
+
     check_host_port localhost 5000 ${keyrock_wait}
 
     while [ true ]; do

--- a/cli/configure_oauth
+++ b/cli/configure_oauth
@@ -84,7 +84,8 @@ function check_host_port () {
     echo "Testing if port '${_port}' is open at host '${_host}'."
 
     while [ ${_tries} -lt ${_max_tries} -a ${_is_open} -eq 0 ] ; do
-        echo -n "Checking connection to '${_host}:${_port}' [try $(( ${_tries} + 1 ))/${_max_tries}] ... "
+        echo -n "Checking connection to '${_host}:${_port}' "
+        echo -n "[try $(( ${_tries} + 1 ))/${_max_tries}] ... "
         if ${NC} -z -w ${_timeout} ${_host} ${_port} ; then
             echo "OK."
             _is_open=1
@@ -100,7 +101,8 @@ function check_host_port () {
     done
 
     if [ ${_is_open} -eq 0 ] ; then
-        echo "Failed to connect to port '${_port}' on host '${_host}' after ${_tries} tries."
+        echo -n "Failed to connect to port '${_port}' on host '${_host}'"
+        echo " after ${_tries} tries."
         echo "Port is closed or host is unreachable."
         exit 1
     else
@@ -120,7 +122,8 @@ function submodule_cmd () {
 
     while [ true ]; do
         echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
-        if ( docker logs ${_tourguide_container} 2>&1 | grep -qE "service apache2 reload" ) ; then
+        if ( docker logs ${_tourguide_container} 2>&1 |
+                 grep -qE "service apache2 reload" ) ; then
             echo "OK."
             _started=1
         fi
@@ -136,12 +139,18 @@ function submodule_cmd () {
 
     if [ ${_started} -eq 1 ]; then
         # get the OAuth credentials for the app
-        CLIENT_ID=$( echo $( docker exec -i ${_keyrock_container} /bin/bash -c 'cat /opt/config.json' ) | grep -Po '(?<="id": ")[^"]*' )
-        CLIENT_SECRET=$( echo $( docker exec -i ${_keyrock_container} /bin/bash -c 'cat /opt/config.json' ) | grep -Po '(?<="secret": ")[^"]*' )
+        CLIENT_ID=$( echo $( docker exec -i ${_keyrock_container} \
+                                    /bin/bash -c 'cat /opt/config.json' ) |
+                           grep -Po '(?<="id": ")[^"]*' )
+        CLIENT_SECRET=$( echo $( docker exec -i ${_keyrock_container} \
+                                        /bin/bash -c 'cat /opt/config.json' ) |
+                               grep -Po '(?<="secret": ")[^"]*' )
+        local c_id="config.clientId = '${CLIENT_ID}'"
+        local c_sec="config.clientSecret = '${CLIENT_SECRET}'"
         docker exec -i ${_tourguide_container} /bin/bash -c \
                "sed -i \${CC_APP_SERVER_PATH}/config.js \
-                -e \"s|config.clientId = 'CLIENT_ID'|config.clientId = '${CLIENT_ID}'|g\" \
-                -e \"s|config.clientSecret = 'CLIENT_SECRET'|config.clientSecret = '${CLIENT_SECRET}'|g\" ; \
+                -e \"s|config.clientId = 'CLIENT_ID'|${c_id}|g\" \
+                -e \"s|config.clientSecret = 'CLIENT_SECRET'|${c_sec}|g\" ; \
                 service apache2 reload"
     else
         echo "Not ready."

--- a/docker/keyrock/access_control_xacml.py
+++ b/docker/keyrock/access_control_xacml.py
@@ -1,0 +1,35 @@
+import logging
+import json
+import os
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'openstack_dashboard.settings'
+from openstack_dashboard import settings
+from openstack_dashboard import fiware_api
+
+with open('/opt/config.json') as data_file:
+    data = json.load(data_file)
+app_id = data['id']
+
+request=None
+
+role_permissions = {}
+public_roles = [
+    role for role in fiware_api.keystone.role_list(
+        request, application=app_id)
+    if role.is_internal == False
+]
+
+for role in public_roles:
+    public_permissions = [
+        perm for perm in fiware_api.keystone.permission_list(
+        request, role=role.id)
+        if perm.is_internal == False
+    ]
+    if public_permissions:
+        role_permissions[role.id] = public_permissions
+
+application = fiware_api.keystone.application_get(request, app_id)
+fiware_api.access_control_ge.policyset_update(
+    request,
+    application=application,
+    role_permissions=role_permissions)

--- a/docker/keyrock/params-config.py
+++ b/docker/keyrock/params-config.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from sqlite3 import dbapi2 as sqlite3
+import json, os, argparse
+
+parser = argparse.ArgumentParser(description='Script to retrieva values from the database')
+parser.add_argument('-n','--name', help='Name of the app to search',required=True)
+parser.add_argument('-f','--file',help='File where to output the results', required=True)
+parser.add_argument('-db','--database',help='Database from where to extract the data', required=True)
+args = parser.parse_args()
+
+def dict_factory(cursor, row):
+    d = {}
+    for idx, col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
+# dict to be shared with the app using a JSON file
+app_config = {}
+
+# Connect to the database
+
+con = sqlite3.connect(args.database)
+con.row_factory = dict_factory
+cur = con.cursor()
+
+# Define the app name to search
+t = (args.name,)
+
+# Extract the Oauth2 client ID
+try:
+    cur.execute("SELECT id AS a FROM consumer_oauth2 WHERE name=?", t)
+    idr = cur.fetchone()["a"]
+except sqlite3.Error as e:
+    print "An error occurred:", e.args[0]
+
+# Extract the Oauth2 secret ID
+try:
+    cur.execute("SELECT secret AS b FROM consumer_oauth2 WHERE name=?", t)
+    secretr = cur.fetchone()["b"]
+except sqlite3.Error as e:
+    print "An error occurred:", e.args[0]
+
+app_config = {'id': idr, 'secret': secretr}
+
+# Extract the organizations names
+try:
+    cur.execute("SELECT name FROM project WHERE name LIKE '%organization%'")
+    orgs = cur.fetchall()
+except sqlite3.Error as e:
+    print "An error occurred:", e.args[0]
+
+orgs_list = []
+for org in orgs:
+    orgs_list.append(org['name'])
+
+app_config['orgs'] = orgs_list;
+
+# Write the JSON file
+f = open(args.file, 'w')
+f.writelines(json.dumps(app_config,
+                        sort_keys=True,
+                        indent=4, separators=(',', ': ')))
+f.close()
+
+
+con.close()

--- a/docker/keyrock/tourguide-provision.py
+++ b/docker/keyrock/tourguide-provision.py
@@ -1,0 +1,212 @@
+# keystone-provision.py
+# Copyright(c) 2016 Bitergia
+# Author: Bitergia <fiware-testing@bitergia.com>
+# MIT Licensed
+#
+# Default provision for tourguide
+
+import json
+import os
+import string
+import code
+import readline
+import rlcompleter
+
+from keystoneclient.v3 import client
+
+IDM_USER_CREDENTIALS = {
+    'username': 'idm',
+    'password': 'idm',
+    'project': 'idm',
+}
+
+def _register_user(keystone, name, activate=True):
+    email = name + '@test.com'
+    user = keystone.user_registration.users.register_user(
+        name=email,
+        password='test',
+        username=name,
+        domain='default')
+    if activate:
+        user = keystone.user_registration.users.activate_user(
+            user=user.id,
+            activation_key=user.activation_key)
+    return user
+
+def _create_organization(keystone, org_name):
+    org = keystone.projects.create(
+        name=org_name,
+        description=('Test '+org_name),
+        domain='default',
+        enabled=True,
+        img='/static/dashboard/img/logos/small/group.png',
+        city='',
+        email='',
+        website='')
+    return org
+
+def test_data(keystone_path='./keystone/'):
+    """Populate the database with some users, organizations and applications
+    for convenience"""
+
+    # Log as idm
+    endpoint = 'http://{ip}:{port}/v3'.format(ip='127.0.0.1',
+                                              port='35357')
+    keystone = client.Client(
+        username=IDM_USER_CREDENTIALS['username'],
+        password=IDM_USER_CREDENTIALS['password'],
+        project_name=IDM_USER_CREDENTIALS['project'],
+        auth_url=endpoint)
+
+    owner_role = keystone.roles.find(name='owner')
+
+    # Create 10 users
+    users = []
+    for i in range(10):
+        username = 'user'
+        users.append(_register_user(keystone, username + str(i)))
+
+    # Register pepProxy user
+
+    pep_user = _register_user(keystone, 'pepproxy')
+
+    # Create Franchises
+
+    franchises = []
+
+    for i in range(4):
+        franchises.append(_create_organization(keystone, 'Franchise' + str(i+1)))
+
+
+    for franchise in franchises:
+        keystone.roles.grant(user=pep_user.id,
+                         role=owner_role.id,
+                         project=franchise.id)
+
+    # Create tourguide APP and give provider role to the pepProxy
+    # TODO: modify the url + callback when the app is ready
+    tourguide_app = keystone.oauth2.consumers.create(
+        name='TourGuide',
+        redirect_uris=['http://tourguide/login'],
+        description='Fiware TourGuide Application',
+        scopes=['all_info'],
+        client_type='confidential',
+        grant_type='authorization_code',
+        url='http://tourguide',
+        img='/static/dashboard/img/logos/small/app.png')
+    provider_role = next(r for r
+                         in keystone.fiware_roles.roles.list()
+                         if r.name == 'Provider')
+
+    keystone.fiware_roles.roles.add_to_user(
+        role=provider_role.id,
+        user=pep_user.id,
+        application=tourguide_app.id,
+        organization=pep_user.default_project_id)
+
+    # Creating roles
+
+    # End user
+    end_user = keystone.fiware_roles.roles.create(
+        name='End user',
+        is_internal=False,
+        application=tourguide_app.id)
+
+    # Franchise manager
+    franchise_manager = keystone.fiware_roles.roles.create(
+        name='Franchise manager',
+        is_internal=False,
+        application=tourguide_app.id)
+
+    # Global manager
+    global_manager = keystone.fiware_roles.roles.create(
+        name='Global manager',
+        is_internal=False,
+        application=tourguide_app.id)
+
+
+    # Make all users Restaurant viewers
+
+    for user in users:
+        keystone.fiware_roles.roles.add_to_user(
+            role=end_user.id,
+            user=user.id,
+            application=tourguide_app.id,
+            organization=user.default_project_id)
+
+    # Make user0 Global Manager
+
+    keystone.fiware_roles.roles.add_to_user(
+        role=global_manager.id,
+        user=users[0].id,
+        application=tourguide_app.id,
+        organization=users[0].default_project_id)
+
+    keystone.fiware_roles.roles.add_to_user(
+        role=franchise_manager.id,
+        user=users[1].id,
+        application=tourguide_app.id,
+        organization=franchises[0].id)
+
+    keystone.fiware_roles.roles.add_to_user(
+        role=franchise_manager.id,
+        user=users[2].id,
+        application=tourguide_app.id,
+        organization=franchises[1].id)
+
+    keystone.fiware_roles.roles.add_to_user(
+        role=franchise_manager.id,
+        user=users[3].id,
+        application=tourguide_app.id,
+        organization=franchises[2].id)
+
+    keystone.fiware_roles.roles.add_to_user(
+        role=franchise_manager.id,
+        user=users[4].id,
+        application=tourguide_app.id,
+        organization=franchises[3].id)
+
+    for i in range(4):
+        keystone.roles.grant(user=users[i+1].id,
+            role=owner_role.id,
+            project=franchises[i].id)
+
+
+    # Make user1-4 Frnanchise Manager
+
+    # Adding permissions for manager and restaurants (TODO)
+
+    perm0 = keystone.fiware_roles.permissions.create(
+                name='reservations',
+                application=tourguide_app,
+                action= 'POST',
+                resource= 'NGSI10/queryContext?limit=1000&entity_type=reservation',
+                is_internal=False)
+
+    keystone.fiware_roles.permissions.add_to_role(
+                    global_manager, perm0)
+
+    perm1 = keystone.fiware_roles.permissions.create(
+                name='reviews',
+                application=tourguide_app,
+                action= 'POST',
+                resource= 'NGSI10/queryContext?limit=1000&entity_type=review',
+                is_internal=False)
+
+    keystone.fiware_roles.permissions.add_to_role(
+                    global_manager, perm1)
+
+    perm2 = keystone.fiware_roles.permissions.create(
+                name='restaurants',
+                application=tourguide_app,
+                action= 'POST',
+                resource= 'NGSI10/queryContext?limit=1000&entity_type=restaurant',
+                is_internal=False)
+
+    keystone.fiware_roles.permissions.add_to_role(
+                    global_manager, perm2)
+
+    keystone.fiware_roles.permissions.add_to_role(
+                    global_manager, perm2)
+
+test_data('./')

--- a/docker/keyrock/tourguide-provision.py
+++ b/docker/keyrock/tourguide-provision.py
@@ -67,16 +67,13 @@ def test_data(keystone_path='./keystone/'):
         users.append(_register_user(keystone, username + str(i)))
 
     # Register pepProxy user
-
     pep_user = _register_user(keystone, 'pepproxy')
 
     # Create Franchises
-
     franchises = []
 
     for i in range(4):
         franchises.append(_create_organization(keystone, 'Franchise' + str(i+1)))
-
 
     for franchise in franchises:
         keystone.roles.grant(user=pep_user.id,
@@ -124,9 +121,7 @@ def test_data(keystone_path='./keystone/'):
         is_internal=False,
         application=tourguide_app.id)
 
-
     # Make all users Restaurant viewers
-
     for user in users:
         keystone.fiware_roles.roles.add_to_user(
             role=end_user.id,
@@ -135,7 +130,6 @@ def test_data(keystone_path='./keystone/'):
             organization=user.default_project_id)
 
     # Make user0 Global Manager
-
     keystone.fiware_roles.roles.add_to_user(
         role=global_manager.id,
         user=users[0].id,
@@ -171,11 +165,8 @@ def test_data(keystone_path='./keystone/'):
             role=owner_role.id,
             project=franchises[i].id)
 
-
     # Make user1-4 Frnanchise Manager
-
     # Adding permissions for manager and restaurants (TODO)
-
     perm0 = keystone.fiware_roles.permissions.create(
                 name='reservations',
                 application=tourguide_app,


### PR DESCRIPTION
This PR adds the `configure`, `configure cygnus`, `configure hosts`, `configure keyrock` and `configure oauth` commands to the CLI. This PR depends on #127.  This PR adds functionality needed by #126.
- `configure cygnus` allows to configure the MySQL user and password for cygnus before starting the service,
- `configure hosts` allows to add the running containers hostname and IP to the `/etc/hosts` file,
- `configure keyrock` allows to provision the sample users, roles and permissions for TourGuide-App,
- `configure oauth` allows to configure the oauth credentials for the TourGuide-App as generated on keyrock after provisioning and reloading this configuration on the tourguide container.
