### PR TITLE
CLI: Add sensors commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -63,13 +63,23 @@ Get the OAuth token for a specific user.  This may be needed to make requests vi
 
 ### sensors ###
 
+Sensors related commands.
+
 #### sensors create ####
+
+Create and initialize sensors for all the restaurants available in the application.
 
 #### sensors update ####
 
+Update all the restaurant sensors measurements.  This will simulate all the available sensors sending new measurements.
+
 #### sensors send-data ####
 
+Send a single measurement for a specific sensor using a Ultralight 2.0 string.
+
 #### sensors simulate-data ####
+
+Simulate a sensor periodically sending data.
 
 ### start ###
 

--- a/cli/sensors
+++ b/cli/sensors
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+#  sensors
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  sensors command for TourGuide CLI.
+#
+
+sensors_command=""
+
+function module_help () {
+    cat <<EOF >&2
+Usage: ${appname} sensors [-h | --help] <command> <options>
+
+Run sensors related commands:
+
+  create                     Create sensors for the restaurants available in the application.
+  update                     Update all restaurant sensors measurements.
+  send-data                  Send a single measurement for a specific sensor.
+  simulate-data              Simulate a sensor sending data over a period of time.
+
+Command options:
+
+  -h  --help                 Show this help.
+
+Use '${appname} sensors <command> --help' to get help about a specific <command>.
+
+EOF
+    exit 0
+}
+
+function module_options () {
+    if [ $# -lt 1 ]; then
+        module_help
+    else
+        case "$1" in
+            "-h" | "--help" )
+                module_help
+                ;;
+            "create"|"update"|"send-data"|"simulate-data")
+                sensors_command="$1"
+                shift
+                ;;
+            "-"*)
+                echo "Unknown parameter: $1"
+                module_help
+                ;;
+            *)
+                echo "Unknown command: $1"
+                module_help
+                ;;
+        esac
+    fi
+}
+
+function module_cmd () {
+    module_options "$@"
+    shift
+    if [ -e "${modules_dir}/${command}_${sensors_command}" ] ; then
+        source "${modules_dir}/${command}_${sensors_command}"
+        submodule_cmd "$@"
+    fi
+}

--- a/cli/sensors_create
+++ b/cli/sensors_create
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+#  sensors_create
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  sensors create subcommand for TourGuide CLI.
+#
+
+sensors_create_wait=0
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} sensors create [-h | --help] [-w | --wait]
+
+Create and initialize sensors for all the restaurants available in the application.
+
+Command options:
+
+  -h  --help                 Show this help.
+  -w  --wait                 Wait for the tourguide container to be ready.
+                             Default is to exit if tourguide container is not ready.
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hw -l help,wait -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-w" | "--wait")
+                shift
+                sensors_create_wait=1
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        module_help
+    fi
+}
+
+function submodule_cmd () {
+    local _started=0
+    local _tries=0
+    local _container_name="${container_prefix}tourguide"
+
+    submodule_options "$@"
+
+    while [ true ]; do
+        echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
+        if ( docker logs ${_container_name} 2>&1 | grep -qE "service apache2 reload" ) ; then
+            echo "OK."
+            _started=1
+        fi
+
+        if [ ${_started} -eq 0 -a ${sensors_create_wait} -eq 1 ]; then
+            sleep 1
+            _tries=$(( ${_tries} + 1 ))
+            echo "Retrying."
+        else
+            break
+        fi
+    done
+
+    if [ ${_started} -eq 1 ]; then
+        docker exec -i -t ${_container_name} /bin/bash -c 'cd tutorials.TourGuide-App/server/feeders; node sensorsgenerator.js'
+    else
+        echo "Not ready."
+        echo "Stopping."
+    fi
+}

--- a/cli/sensors_send-data
+++ b/cli/sensors_send-data
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+#  sensors_send-data
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  sensors send-data subcommand for TourGuide CLI.
+#
+
+sensors_id=""
+sensors_ul20=""
+idas_host="localhost"
+idas_ul20_port="7896"
+idas_api_key="tourguide-devices"
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} sensors send-data [-h | --help] [-i <sensorId> | --sensor-id <sensorId>]
+                                    [ -d <ul20-string> | --data <ul20-string> ]
+
+Send a single measurement for a specific sensor using a Ultralight 2.0 string.
+
+Command options:
+
+  -h  --help                 Show this help.
+
+Required parameters:
+
+  -i  --sensor-id  <sensorId>     The sensor Id to modify.  The Id format is '<restaurantId>-<room>-<type>', with
+                                  <restaurantId> being the Id of the restaurant where the sensor is located,
+                                  <room> the room of the restaurant: kitchen, diner,
+                                  <type> the type of the sensor: temperature, relativeHumidity.
+  -d  --data <ul20-string>        The string to send with the new measurement.  Examples of this are:
+                                  't|20' for temperature (20 C),
+                                  'h|0.4' for relativeHumidity (40%).
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hi:d: -l help,sensor-id:,data: -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-i" | "--sensor-id" )
+                shift
+                sensors_id=$1
+                ;;
+            "-d" | "--data" )
+                shift
+                sensors_ul20=$1
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        submodule_help
+    fi
+
+    local missing_parameters=0
+    [ -z "${sensors_id}" ] && echo "Missing parameter '--sensor-id'." && missing_parameters=1
+    [ -z "${sensors_ul20}" ] && echo "Missing parameter '--data'." && missing_parameters=1
+
+    [ ${missing_parameters} -ne 0 ] && submodule_help
+}
+
+function submodule_cmd () {
+    submodule_options "$@"
+
+    # get restaurant id from sensor id
+    restaurant_id=$( echo ${sensors_id} | cut -d "-" -f 1 )
+
+    # get fiware-servicepath for the restaurant
+    fiware_servicepath=$( curl --silent \
+                               --show-error \
+                               --header "Fiware-Service: ${fiware_service}" \
+                               --header "Accept: text/plain" \
+                               "http://localhost:1026/v2/entities/${restaurant_id}/attrs/department/value" )
+
+    curl --request POST \
+         --header "Content-Type: text/plain" \
+         --header "Fiware-Service: ${fiware_service}" \
+         --header "Fiware-ServicePath: /${fiware_servicepath}" \
+         --header "X-Auth-Token: NULL" \
+         --data "${sensors_ul20}" \
+         "http://${idas_host}:${idas_ul20_port}/iot/d?k=${idas_api_key}&i=${sensors_id}"
+}

--- a/cli/sensors_send-data
+++ b/cli/sensors_send-data
@@ -93,12 +93,12 @@ function submodule_cmd () {
                                --header "Fiware-Service: ${fiware_service}" \
                                --header "Accept: text/plain" \
                                "http://localhost:1026/v2/entities/${restaurant_id}/attrs/department/value" )
-
+    local api_key="${idas_api_key}-${fiware_servicepath}"
     curl --request POST \
          --header "Content-Type: text/plain" \
          --header "Fiware-Service: ${fiware_service}" \
          --header "Fiware-ServicePath: /${fiware_servicepath}" \
          --header "X-Auth-Token: NULL" \
          --data "${sensors_ul20}" \
-         "http://${idas_host}:${idas_ul20_port}/iot/d?k=${idas_api_key}&i=${sensors_id}"
+         "http://${idas_host}:${idas_ul20_port}/iot/d?k=${api_key}&i=${sensors_id}"
 }

--- a/cli/sensors_send-data
+++ b/cli/sensors_send-data
@@ -92,7 +92,8 @@ function submodule_cmd () {
                                --show-error \
                                --header "Fiware-Service: ${fiware_service}" \
                                --header "Accept: text/plain" \
-                               "http://localhost:1026/v2/entities/${restaurant_id}/attrs/department/value" )
+                               "http://localhost:1026/v2/entities/${restaurant_id}/attrs/department/value" |
+                          tr -d '"')
     local api_key="${idas_api_key}-${fiware_servicepath}"
     curl --request POST \
          --header "Content-Type: text/plain" \

--- a/cli/sensors_simulate-data
+++ b/cli/sensors_simulate-data
@@ -109,7 +109,7 @@ function sensor_get_old_value () {
                             --header "Fiware-Service: ${fiware_service}" \
                             --header "Accept: text/plain" \
                             "http://localhost:1026/v2/entities/${restaurant_id}/attrs/${type}:${room}/value" )
-    echo ${old_value}
+    echo ${old_value} | tr -d '"'
 }
 
 function generate_sensor_value () {
@@ -154,7 +154,8 @@ function submodule_cmd () {
                                --show-error \
                                --header "Fiware-Service: ${fiware_service}" \
                                --header "Accept: text/plain" \
-                               "http://localhost:1026/v2/entities/${restaurant_id}/attrs/department/value" )
+                               "http://localhost:1026/v2/entities/${restaurant_id}/attrs/department/value" |
+                          tr -d '"')
     local api_key="${idas_api_key}-${fiware_servicepath}"
 
     while true ; do

--- a/cli/sensors_simulate-data
+++ b/cli/sensors_simulate-data
@@ -155,6 +155,7 @@ function submodule_cmd () {
                                --header "Fiware-Service: ${fiware_service}" \
                                --header "Accept: text/plain" \
                                "http://localhost:1026/v2/entities/${restaurant_id}/attrs/department/value" )
+    local api_key="${idas_api_key}-${fiware_servicepath}"
 
     while true ; do
         local old_value=$( sensor_get_old_value ${restaurant_id} ${room} ${sensors_type} )
@@ -181,7 +182,7 @@ function submodule_cmd () {
              --header "Fiware-ServicePath: ${fiware_servicepath}" \
              --header "X-Auth-Token: NULL" \
              --data "${sensors_ul20}" \
-             "http://${idas_host}:${idas_ul20_port}/iot/d?k=${idas_api_key}&i=${sensors_id}"
+             "http://${idas_host}:${idas_ul20_port}/iot/d?k=${api_key}&i=${sensors_id}"
 
         echo "sensor: ${sensors_id} | value: ${sensors_ul20}"
 

--- a/cli/sensors_simulate-data
+++ b/cli/sensors_simulate-data
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+#  sensors_simulate-data
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  sensors simulate-data subcommand for TourGuide CLI.
+#
+
+sensors_id=""
+sensors_type=""
+sensors_delay=""
+
+idas_host="localhost"
+idas_ul20_port="7896"
+idas_api_key="tourguide-devices"
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} sensors simulate-data [-h | --help] [-i <sensorId> | --sensor-id <sensorId>]
+                                        [ -t <type> | --type <type> ] [ -d <n> | --delay <n> ]
+
+Simulate a sensor periodically sending data.
+
+Command options:
+
+  -h  --help                 Show this help.
+
+Required parameters:
+
+  -i  --sensor-id  <sensorId>     The sensor Id to modify.  The Id format is '<restaurantId>-<room>-<type>', with
+                                  <restaurantId> being the Id of the restaurant where the sensor is located,
+                                  <room> the room of the restaurant: kitchen, diner,
+                                  <type> the type of the sensor: temperature, relativeHumidity.
+  -t  --type <type>               Type of the sensor.  This must be the same type specified in the sensor Id.
+                                  Valid values: temperature, relativeHumidity.
+  -d  --delay <n>                 Delay in seconds between sensor readings.
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hi:t:d: -l help,sensor-id:,type:,data: -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-i" | "--sensor-id" )
+                shift
+                sensors_id=$1
+                ;;
+            "-t" | "--type" )
+                shift
+                sensors_type=$1
+                ;;
+            "-d" | "--delay" )
+                shift
+                sensors_delay=$1
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        submodule_help
+    fi
+
+    local missing_parameters=0
+    [ -z "${sensors_id}" ] && echo "Missing parameter '--sensor-id'." && missing_parameters=1
+
+    if [ -z "${sensors_type}" ] ; then
+        echo "Missing parameter '--type'." && missing_parameters=1
+    else
+        [ "${sensors_type}" != "temperature" -a "${sensors_type}" != "relativeHumidity" ] && echo "Unknown sensor type: ${sensors_type}." && missing_parameters=1
+    fi
+
+    if [ -z "${sensors_delay}" ] ; then
+        echo "Missing parameter '--delay'." && missing_parameters=1
+    else
+        [[ ! ${sensors_delay} =~ ^\+?[0-9]+$ ]] && echo "Delay value must be a positive integer." && missing_parameters=1
+        [ ${sensors_delay} -lt 1 ] && echo "Delay value must be greater than 0." && missing_parameters=1
+    fi
+
+    [ ${missing_parameters} -ne 0 ] && submodule_help
+}
+
+function sensor_get_old_value () {
+    local restaurant_id="$1"
+    local room="$2"
+    local type="$3"
+
+    local old_value=$( curl --silent \
+                            --show-error \
+                            --header "Fiware-Service: ${fiware_service}" \
+                            --header "Accept: text/plain" \
+                            "http://localhost:1026/v2/entities/${restaurant_id}/attrs/${type}:${room}/value" )
+    echo ${old_value}
+}
+
+function generate_sensor_value () {
+    local old_value="$1"
+    local type="$2"
+    local new_value=${old_value}
+    local MIN=0
+    local MAX=100
+
+    if [ "${type}" = "relativeHumidity" ]; then
+        old_value=$( echo "${old_value} * 100" | bc )
+        old_value=${old_value%.*}
+    fi
+
+    local var_sign=$(( $RANDOM % 2 ))
+    local var_val=$(( $RANDOM % 4 ))
+
+    if [ ${var_sign} -eq 0 ] ; then
+        new_value=$(( ${old_value} + ${var_val} ))
+        [ ${new_value} -gt ${MAX} ] && new_value=${MAX}
+    else
+        new_value=$(( ${old_value} - ${var_val} ))
+        [ ${new_value} -lt ${MIN} ] && new_value=${MIN}
+    fi
+
+    if [ "${type}" = "relativeHumidity" ]; then
+        new_value=$( echo "scale=2; ${new_value} / 100" | bc )
+    fi
+
+    echo "${new_value}"
+}
+
+function submodule_cmd () {
+    submodule_options "$@"
+
+    # get restaurant id from sensor id
+    local restaurant_id=$( echo ${sensors_id} | cut -d "-" -f 1 )
+    local room=$( echo ${sensors_id} | cut -d "-" -f 2 )
+
+    # get fiware-servicepath for the restaurant
+    fiware_servicepath=$( curl --silent \
+                               --show-error \
+                               --header "Fiware-Service: ${fiware_service}" \
+                               --header "Accept: text/plain" \
+                               "http://localhost:1026/v2/entities/${restaurant_id}/attrs/department/value" )
+
+    while true ; do
+        local old_value=$( sensor_get_old_value ${restaurant_id} ${room} ${sensors_type} )
+        local new_value=$( generate_sensor_value ${old_value} ${sensors_type} )
+        local sensors_ul20=""
+        case "${sensors_type}" in
+            "temperature")
+                sensors_ul20="t|${new_value}"
+                ;;
+            "relativeHumidity")
+                sensors_ul20="h|${new_value}"
+                ;;
+            *)
+                echo "Unknown type: ${sensors_type}"
+                submodule_help
+                ;;
+        esac
+
+        curl --request POST \
+             --silent \
+             --show-error \
+             --header "Content-Type: text/plain" \
+             --header "Fiware-Service: ${fiware_service}" \
+             --header "Fiware-ServicePath: ${fiware_servicepath}" \
+             --header "X-Auth-Token: NULL" \
+             --data "${sensors_ul20}" \
+             "http://${idas_host}:${idas_ul20_port}/iot/d?k=${idas_api_key}&i=${sensors_id}"
+
+        echo "sensor: ${sensors_id} | value: ${sensors_ul20}"
+
+        if [ "${sensors_delay}" != "" ] ; then
+            sleep ${sensors_delay}
+        else
+            break;
+        fi
+    done
+}

--- a/cli/sensors_update
+++ b/cli/sensors_update
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+#  sensors_update
+#  Copyright(c) 2016 Bitergia
+#  Author: Bitergia <fiware-testing@bitergia.com>
+#  MIT Licensed
+#
+#  sensors update subcommand for TourGuide CLI.
+#
+
+sensors_update_wait=0
+
+function submodule_help () {
+    cat <<EOF >&2
+Usage: ${appname} sensors update [-h | --help] [-w | --wait]
+
+Update all the restaurant sensors measurements.  This will simulate
+all the available sensors sending new measurements.
+
+Command options:
+
+  -h  --help                 Show this help.
+  -w  --wait                 Wait for the tourguide container to be ready.
+                             Default is to exit if tourguide container is not ready.
+
+EOF
+    exit 0
+}
+
+function submodule_options () {
+    TEMP=`getopt -o hw -l help,wait -- "$@"`
+
+    if test "$?" -ne 0 ; then
+        submodule_help
+    fi
+
+    eval set -- "$TEMP"
+
+    while true ; do
+        case "$1" in
+            "-h" | "--help" )
+                submodule_help
+                ;;
+            "-w" | "--wait")
+                shift
+                sensors_update_wait=1
+                ;;
+            --|*)
+                break;
+                ;;
+        esac
+        shift
+    done
+    shift
+
+    if [ $# -gt 0 ]; then
+        echo "Unknown parameters: $@"
+        module_help
+    fi
+}
+
+function submodule_cmd () {
+    local _started=0
+    local _tries=0
+    local _container_name="${container_prefix}tourguide"
+
+    submodule_options "$@"
+
+    while [ true ]; do
+        echo -n "Waiting for tourguide to be ready [$(( ${_tries} + 1 ))]... "
+        if ( docker logs ${_container_name} 2>&1 | grep -qE "service apache2 reload" ) ; then
+            echo "OK."
+            _started=1
+        fi
+
+        if [ ${_started} -eq 0 -a ${sensors_update_wait} -eq 1 ]; then
+            sleep 1
+            _tries=$(( ${_tries} + 1 ))
+            echo "Retrying."
+        else
+            break
+        fi
+    done
+
+    if [ ${_started} -eq 1 ]; then
+        docker exec -i -t ${_container_name} /bin/bash -c 'cd tutorials.TourGuide-App/server/feeders; node sensorsupdater.js'
+    else
+        echo "Not ready."
+        echo "Stopping."
+    fi
+}

--- a/server/feeders/sensorsgenerator.js
+++ b/server/feeders/sensorsgenerator.js
@@ -18,6 +18,7 @@
 var utils = require('../utils');
 var idas = require('../idas/ul20');
 var config = require('../config');
+var Q = require('q');
 var fiwareHeaders = {
   'fiware-service': config.fiwareService
 };
@@ -29,6 +30,12 @@ var fiwareHeaders = {
  * - Humidity of the Dining room
  */
 
+var organization = [
+  'Franchise1',
+  'Franchise2',
+  'Franchise3',
+  'Franchise4'
+];
 var sensorTypes = ['temperature', 'relativeHumidity'];
 var sensorRooms = ['kitchen', 'dining'];
 var sensorsPerRestaurant = sensorTypes.length * sensorRooms.length;
@@ -72,7 +79,11 @@ function feedIDASSensors(restaurantsData) {
 
 console.log('Generating sensors for restaurants...');
 
-idas.createService()
+var services = organization.map(function(org) {
+  return idas.createService(org);
+});
+
+Q.all(services)
   .then(function(response) {
     // Get all the restaurants from Orion.
     return utils.getListByType('Restaurant', null, fiwareHeaders);

--- a/server/idas/ul20.js
+++ b/server/idas/ul20.js
@@ -69,18 +69,28 @@ var sensorsTemplates = {
  *
  * @return {Promise} response of the IoT Agent.
 */
-function createService() {
+function createService(servicePath) {
   var idasUrl = '/iot/services';
   var headers = JSON.parse(JSON.stringify(defaultHeaders));
   var RESOURCE = '/iot/d';
+  var apiKey = idasApiKey;
+
+  if (!servicePath) {
+    servicePath = idasFiwareServicePath;
+  } else {
+    apiKey += '-' + servicePath;
+  }
+
+  headers = utils.completeHeaders(headers, servicePath);
 
   // build payload
   var data = {
     'services': [
       {
-        'apikey': '' + idasApiKey + '',
+        'apikey': '' + apiKey + '',
         'cbroker': 'http://' + orionHostname + ':' + orionPort + '',
-        'resource': RESOURCE
+        'resource': RESOURCE,
+        'entity_type': 'Restaurant'
       }
     ]
   };
@@ -221,8 +231,12 @@ function registerSensor(restaurant, room, type) {
 function sendObservation(deviceId, data, servicePath) {
   var idasUrl = '/iot/d';
   var headers = JSON.parse(JSON.stringify(defaultHeaders));
+  var apiKey = idasApiKey;
+  if (servicePath) {
+    apiKey += '-' + servicePath;
+  }
   var idasParams = [
-    'k=' + idasApiKey,
+    'k=' + apiKey,
     'i=' + encodeURIComponent(deviceId)
   ];
 


### PR DESCRIPTION
This PR adds the `sensors`, `sensors create`, `sensors update`, `sensors send-data` and `sensors simulate-data` commands to the CLI. This PR depends on #127.
- `sensors create` allows to create sensors for all the available restaurants,
- `sensors update` allows to update all the sensors for all the available restaurants,
- `sensors send-data` allows to send sensor measurements using UL20 for a single sensor,
- `sensors simulate-data` allows to simulate a sensor sending data over time.

This will fail until https://github.com/telefonicaid/iotagent-ul/issues/135 is fixed.
