### PR TITLE
Fix cygnus subscriptions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ cygnus:
     container_name: cygnus
     links:
         - orion
-        - mysql
+        - mysql:iot-mysql
     expose:
         - "5050"
     environment:

--- a/docker/cygnus/subscriptions/subscription-humidity-sensors.sh
+++ b/docker/cygnus/subscriptions/subscription-humidity-sensors.sh
@@ -9,7 +9,9 @@
 CYGNUS_HOST=$( getent hosts cygnus | sort -u | awk '{print $1}' )
 CYGNUS_PORT=5050
 CYGNUS_URL=http://${CYGNUS_HOST}:${CYGNUS_PORT}/notify
-ORION_URL=http://${ORION_HOSTNAME}:${ORION_PORT}/v1/subscribeContext
+ORION_HOST=$( getent hosts orion | sort -u | awk '{print $1}' )
+ORION_PORT=1026
+ORION_URL=http://${ORION_HOST}:${ORION_PORT}/v1/subscribeContext
 
 cat <<EOF | curl ${ORION_URL} -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Fiware-Service: tourguide' --header 'Fiware-ServicePath: /#' -d @-
 {

--- a/docker/cygnus/subscriptions/subscription-therm-sensors.sh
+++ b/docker/cygnus/subscriptions/subscription-therm-sensors.sh
@@ -10,7 +10,9 @@
 CYGNUS_HOST=$( getent hosts cygnus | sort -u | awk '{print $1}' )
 CYGNUS_PORT=5050
 CYGNUS_URL=http://${CYGNUS_HOST}:${CYGNUS_PORT}/notify
-ORION_URL=http://${ORION_HOSTNAME}:${ORION_PORT}/v1/subscribeContext
+ORION_HOST=$( getent hosts orion | sort -u | awk '{print $1}' )
+ORION_PORT=1026
+ORION_URL=http://${ORION_HOST}:${ORION_PORT}/v1/subscribeContext
 
 cat <<EOF | curl ${ORION_URL} -s -S --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Fiware-Service: tourguide' --header 'Fiware-ServicePath: /#' -d @-
 {


### PR DESCRIPTION
This PR adds a change to the sample subscription scripts to allow them to run from the hosts.  Prior to this it was only possible to run the scripts from the tourguide container.
