### PR TITLE
Use --fake sensor by default for ul20-client.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ ul20client:
     links:
         - orion
         - idas
-    command: --acpi
+    command: --fake --min 0 --max 100 --variance 5
     environment:
         - UL20_IOTA_HOST=idas
         - UL20_IOTA_PORT=7896


### PR DESCRIPTION
Using --acpi as default generates an error on systems without acpi, shutting down the container.  This fixes that by using a fake sensor.
